### PR TITLE
CRDL-250 Correct the prod routes to include the context path

### DIFF
--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,3 +1,3 @@
 # Add all the application routes to the app.routes file
-->         /                          app.Routes
+->         /crdl-cache                app.Routes
 ->         /                          health.Routes


### PR DESCRIPTION
I missed this when migrating away from the API template