### PR TITLE
CRDL-315 Implement filtering of codelist entries by key

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ This endpoint is used to fetch entries of a reference data codelist.
 
     * `code: String` - The codelist code, e.g. `BC08`, `BC36`.
 
+<!-- The `activeAt` parameter is undocumented for now as we await historical data bugfixes at DPS
 * **Query Parameters**
 
   **Optional:**
 
     * `activeAt: Instant` - The timestamp at which to view entries. If omitted the current timestamp is used.
+-->
 
 * **Success Response:**
     * **Status:** 200 <br/>

--- a/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
@@ -36,10 +36,11 @@ class CodeListsController @Inject() (
 
   def fetchCodeListEntries(
     codeListCode: CodeListCode,
+    filterKeys: Option[Set[String]],
     activeAt: Option[Instant]
   ): Action[AnyContent] = Action.async { _ =>
     codeListsRepository
-      .fetchCodeListEntries(codeListCode, activeAt.getOrElse(clock.instant()))
+      .fetchCodeListEntries(codeListCode, filterKeys, activeAt.getOrElse(clock.instant()))
       .map { entries =>
         Ok(Json.toJson(entries))
       }

--- a/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
@@ -17,15 +17,15 @@
 package uk.gov.hmrc.crdlcache.repositories
 
 import com.mongodb.client.model.ReplaceOptions
-import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions, Indexes, Sorts, Updates}
+import org.mongodb.scala.*
+import org.mongodb.scala.bson.BsonNull
+import org.mongodb.scala.model.*
+import org.mongodb.scala.model.Filters.*
+import uk.gov.hmrc.crdlcache.models
+import uk.gov.hmrc.crdlcache.models.errors.MongoError
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry, Instruction}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
-import org.mongodb.scala.model.Filters.*
-import org.mongodb.scala.*
-import org.mongodb.scala.bson.BsonNull
-import uk.gov.hmrc.crdlcache.models
-import uk.gov.hmrc.crdlcache.models.errors.MongoError
 import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
 
 import java.time.Instant
@@ -64,17 +64,28 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
       .toFuture
       .map(_.toSet)
 
-  def fetchCodeListEntries(code: CodeListCode, activeAt: Instant): Future[Seq[CodeListEntry]] =
+  def fetchCodeListEntries(
+    code: CodeListCode,
+    filterKeys: Option[Set[String]],
+    activeAt: Instant
+  ): Future[Seq[CodeListEntry]] = {
+    val mandatoryFilters = List(
+      equal("codeListCode", code.code),
+      lte("activeFrom", activeAt),
+      or(equal("activeTo", null), gt("activeTo", activeAt))
+    )
+
+    val optionalFilters = filterKeys
+      .map(ks => if ks.nonEmpty then List(in("key", ks.toSeq*)) else List.empty)
+      .getOrElse(List.empty)
+
+    val allFilters = mandatoryFilters ++ optionalFilters
+
     collection
-      .find(
-        and(
-          equal("codeListCode", code.code),
-          lte("activeFrom", activeAt),
-          or(equal("activeTo", null), gt("activeTo", activeAt))
-        )
-      )
+      .find(and(allFilters*))
       .sort(Sorts.ascending("key"))
       .toFuture()
+  }
 
   private def supersedePreviousEntries(
     session: ClientSession,

--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,16 @@ lazy val microservice = Project("crdl-cache", file("."))
     scalacOptions ++= Seq(
       "-Wconf:src=routes/.*:s",
       "-Wconf:msg=Flag.*repeatedly:s",
-      "--coverage-exclude-classlikes:uk.gov.hmrc.crdlcache.controllers.testonly"
+      // Ignore test-only code
+      "--coverage-exclude-classlikes:uk.gov.hmrc.crdlcache.controllers.testonly",
+      // Ignore test-only API documentation view
+      "--coverage-exclude-classlikes:uk.gov.hmrc.crdlcache.views.html"
     ),
     routesImport ++= Seq(
       "java.time.Instant",
       "uk.gov.hmrc.crdlcache.models.*",
-      "uk.gov.hmrc.crdlcache.models.Binders.bindableInstant"
+      "uk.gov.hmrc.crdlcache.models.Binders.bindableInstant",
+      "uk.gov.hmrc.crdlcache.models.Binders.bindableSet"
     ),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
   )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,3 @@
 # microservice specific routes
 
-GET        /lists/:code        uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListEntries(code: CodeListCode, activeAt: Option[Instant])
+GET        /lists/:code        uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListEntries(code: CodeListCode, keys: Option[Set[String]] ?= None, activeAt: Option[Instant])

--- a/it/test/uk/gov/hmrc/crdlcache/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/repositories/CodeListsRepositorySpec.scala
@@ -229,25 +229,77 @@ class CodeListsRepositorySpec
     codelistEntries
   ) {
     repository
-      .fetchCodeListEntries(BC08, activeAt = Instant.parse("2025-06-05T00:00:00Z"))
+      .fetchCodeListEntries(
+        BC08,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .futureValue must contain allElementsOf activeCodelistEntries
+  }
+
+  it should "apply filtering of entries according to the supplied keys" in withCodeListEntries(
+    codelistEntries
+  ) {
+    repository
+      .fetchCodeListEntries(
+        BC08,
+        filterKeys = Some(Set("AW", "BL")),
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .futureValue must contain allElementsOf activeCodelistEntries.take(2)
+  }
+
+  it should "not apply filtering of entries when the set of supplied keys is empty" in withCodeListEntries(
+    codelistEntries
+  ) {
+    repository
+      .fetchCodeListEntries(
+        BC08,
+        filterKeys = Some(Set.empty),
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
       .futureValue must contain allElementsOf activeCodelistEntries
   }
 
   it should "not return entries from other lists" in withCodeListEntries(codelistEntries) {
     repository
-      .fetchCodeListEntries(BC08, activeAt = Instant.parse("2025-06-05T00:00:00Z"))
+      .fetchCodeListEntries(
+        BC08,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .futureValue must contain noElementsOf differentCodeListEntries
+  }
+
+  it should "not return entries from other lists even when matching keys are specified" in withCodeListEntries(
+    codelistEntries
+  ) {
+    repository
+      .fetchCodeListEntries(
+        BC08,
+        filterKeys = Some(Set("B")),
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
       .futureValue must contain noElementsOf differentCodeListEntries
   }
 
   it should "not return entries that have been superseded" in withCodeListEntries(codelistEntries) {
     repository
-      .fetchCodeListEntries(BC08, activeAt = Instant.parse("2025-06-05T00:00:00Z"))
+      .fetchCodeListEntries(
+        BC08,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
       .futureValue must contain noElementsOf supersededCodeListEntries
   }
 
   it should "not return entries that are not yet active" in withCodeListEntries(codelistEntries) {
     repository
-      .fetchCodeListEntries(BC08, activeAt = Instant.parse("2025-06-05T00:00:00Z"))
+      .fetchCodeListEntries(
+        BC08,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
       .futureValue mustNot contain(postDatedEntry)
   }
 
@@ -255,7 +307,11 @@ class CodeListsRepositorySpec
     codelistEntries
   ) {
     repository
-      .fetchCodeListEntries(BC08, activeAt = Instant.parse("2025-06-05T00:00:00Z"))
+      .fetchCodeListEntries(
+        BC08,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
       .futureValue must contain(invalidatedIoEntry)
   }
 

--- a/public/api/1.0/openapi.yaml
+++ b/public/api/1.0/openapi.yaml
@@ -60,16 +60,30 @@ paths:
               - BC08
               - BC36
               - CL239
-        - name: activeAt
+        - name: keys
           in: query
           description: |
-            The timestamp at which to view entries. If omitted the current timestamp is used.
-            Historical data support is best-effort only as it requires cooperation from the DPS API.
+            Used to specify the keys of entries to return in the response.
           required: false
           schema:
-            type: string
-            format: date-time
-            example: "2025-06-05T00:00:00Z"
+            type: array
+            items:
+              type: string
+              example: [ "GB", "XI" ]
+              examples:
+                - [ "GB", "XI" ]
+                - [ "B000", "E200" ]
+        # The `activeAt` parameter is undocumented for now as we await historical data bugfixes at DPS
+        # - name: activeAt
+        #   in: query
+        #   description: |
+        #     The timestamp at which to view entries. If omitted the current timestamp is used.
+        #     Historical data support is best-effort only as it requires cooperation from the DPS API.
+        #   required: false
+        #   schema:
+        #     type: string
+        #     format: date-time
+        #     example: "2025-06-05T00:00:00Z"
       responses:
         200:
           description: OK

--- a/test/uk/gov/hmrc/crdlcache/models/BindersSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/models/BindersSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.models
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{EitherValues, OptionValues}
+
+import java.time.Instant
+
+class BindersSpec
+  extends AnyFlatSpec
+  with Matchers
+  with TableDrivenPropertyChecks
+  with OptionValues
+  with EitherValues {
+
+  private val instantValues = Table(
+    ("inputString", "isValid", "instantValue"),
+    ("2025-06-05T00:00:00Z", true, Instant.parse("2025-06-05T00:00:00Z")),
+    ("2025-06-12T12:40:32.123Z", true, Instant.parse("2025-06-12T12:40:32.123Z")),
+    ("2025-06-05T00:00:00 Europe/London", false, null),
+    ("bla", false, null)
+  )
+
+  "Binders.bindableInstant" should "bind a Java Instant value from a query string" in forAll(
+    instantValues
+  ) { (inputString, isValid, expectedValue) =>
+    val result = Binders.bindableInstant.bind("key", Map("key" -> Seq(inputString)))
+    if (isValid) result mustBe Some(Right(expectedValue))
+    else result.value.left.value must startWith("Cannot parse parameter key as Instant:")
+  }
+
+  it should "unbind a Java Instant value into a query string" in forAll(instantValues) {
+    (inputString, isValid, instantValue) =>
+      whenever(isValid) {
+        Binders.bindableInstant.unbind("key", instantValue) mustBe s"key=$inputString"
+      }
+  }
+
+  private val stringSetValues = Table(
+    ("inputString", "setValue"),
+    ("GB,XI", Set("GB", "XI")),
+    ("GB", Set("GB")),
+    ("", Set.empty)
+  )
+
+  private val intSetValues = Table(
+    ("inputString", "isValid", "setValue"),
+    ("1,2", true, Set(1, 2)),
+    ("1", true, Set(1)),
+    ("", true, Set.empty),
+    ("A", false, null),
+    ("A,B", false, null)
+  )
+
+  "Binders.bindableSet" should "bind a Set of String values from a query string" in forAll(
+    stringSetValues
+  ) { (inputString, setValue) =>
+    val result = Binders.bindableSet[String].bind("key", Map("key" -> Seq(inputString)))
+    result mustBe Some(Right(setValue))
+  }
+
+  it should "bind a Set of Int values from a query string" in forAll(
+    intSetValues
+  ) { (inputString, isValid, setValue) =>
+    val result = Binders.bindableSet[Int].bind("key", Map("key" -> Seq(inputString)))
+    if (isValid) result mustBe Some(Right(setValue))
+    else result.value.left.value must startWith("Cannot parse parameter key as Int:")
+  }
+
+  it should "unbind a Set of String values into a query string as separate parameter occurrences" in forAll(
+    stringSetValues
+  ) { (_, setValue) =>
+    val result = Binders.bindableSet.unbind("key", setValue)
+    setValue.foreach { value => result must include(s"key=$value") }
+  }
+
+  it should "unbind a Set of Int values into a query string as separate parameter occurrences" in forAll(
+    intSetValues
+  ) { (_, isValid, setValue) =>
+    whenever(isValid) {
+      val result = Binders.bindableSet.unbind("key", setValue)
+      setValue.foreach { value => result must include(s"key=$value") }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds filtering of codelist entries by key to the Fetch Codelist Entries endpoint.

This can be done by providing the `keys` query parameter with a comma-separated list of values, e.g.

`/crdl-cache/lists/BC08?keys=GB,XI`
`/crdl-cache/lists/BC08?keys=GB&keys=XI`
`/crdl-cache/lists/BC08?keys=AW,BL&keys=BM`