### PR TITLE
CRDL-316 Implement filtering of codelist entries by entry properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,28 @@ This endpoint is used to fetch entries of a reference data codelist.
 
     * `code: String` - The codelist code, e.g. `BC08`, `BC36`.
 
-<!-- The `activeAt` parameter is undocumented for now as we await historical data bugfixes at DPS
 * **Query Parameters**
 
   **Optional:**
 
+    * `keys: Seq[String]`
+      
+      Used to specify the keys of entries to return in the response.
+            
+      You can provide comma-separated values for keys, or provide multiple occurrences of the `keys` parameter, or both.
+            
+      For example: `?keys=AW,BL&keys=XI&keys=GB`.
+
+    <!-- The `activeAt` parameter is undocumented for now as we await historical data bugfixes at DPS
     * `activeAt: Instant` - The timestamp at which to view entries. If omitted the current timestamp is used.
--->
+    -->
+
+    * Any other query parameter name can be used for filtering feed-specific and codelist-specific properties.
+    
+      You do not need to prefix the query parameter with `properties`.
+            
+      For example: `?unitOfMeasureCode=3&responsibleDataManager=null`.
+
 
 * **Success Response:**
     * **Status:** 200 <br/>

--- a/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.crdlcache.controllers
 
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry}
 import uk.gov.hmrc.crdlcache.repositories.CodeListsRepository
@@ -37,10 +37,16 @@ class CodeListsController @Inject() (
   def fetchCodeListEntries(
     codeListCode: CodeListCode,
     filterKeys: Option[Set[String]],
+    filterProperties: Option[Map[String, JsValue]],
     activeAt: Option[Instant]
   ): Action[AnyContent] = Action.async { _ =>
     codeListsRepository
-      .fetchCodeListEntries(codeListCode, filterKeys, activeAt.getOrElse(clock.instant()))
+      .fetchCodeListEntries(
+        codeListCode,
+        filterKeys,
+        filterProperties,
+        activeAt.getOrElse(clock.instant())
+      )
       .map { entries =>
         Ok(Json.toJson(entries))
       }

--- a/app/uk/gov/hmrc/crdlcache/models/Binders.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/Binders.scala
@@ -23,8 +23,9 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 
 object Binders {
-  private val formatter = DateTimeFormatter.ISO_INSTANT
-  private val KeysParam = "keys"
+  private val formatter     = DateTimeFormatter.ISO_INSTANT
+  private val KeysParam     = "keys"
+  private val ActiveAtParam = "activeAt"
 
   given bindableInstant: QueryStringBindable[Instant] = new QueryStringBindable.Parsing[Instant](
     Instant.parse,
@@ -65,8 +66,10 @@ object Binders {
         params: Map[String, Seq[String]]
       ): Option[Either[String, Map[String, JsValue]]] = {
         val parsedProps = for {
-          (propName, propValues) <- params.removed(KeysParam) // Ignore the "keys" query parameter
-          propValue              <- propValues.headOption
+          (propName, propValues) <- params
+            .removed(KeysParam)
+            .removed(ActiveAtParam) // Ignore the "keys" and "activeAt" query parameters
+          propValue <- propValues.headOption
           if propValue.nonEmpty
         } yield propName -> parsePropValue(propValue)
 

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListCode.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListCode.scala
@@ -19,23 +19,26 @@ package uk.gov.hmrc.crdlcache.models
 import play.api.libs.json.Format
 import play.api.mvc.PathBindable
 
-sealed abstract class CodeListCode(val code: String) extends Product with Serializable {}
+enum CodeListCode(val code: String) {
+  // BC08 (Country)
+  case BC08                               extends CodeListCode("BC08")
+  // BC36 (Excise Products)
+  case BC36                               extends CodeListCode("BC36")
+  // BC66 (Excise Products Category)
+  case BC66                               extends CodeListCode("BC66")
+  // CL141 (Customs Offices)
+  case CL141                              extends CodeListCode("CL141")
+  // Unknown codelist code
+  case Unknown(override val code: String) extends CodeListCode(code)
+}
 
 object CodeListCode {
-  // BC08 (Country)
-  case object BC08 extends CodeListCode("BC08")
-  // BC66 (Excise Products Category)
-  case object BC66 extends CodeListCode("BC66")
-  // CL141 (Customs Offices)
-  case object CL141 extends CodeListCode("CL141")
-  // Unknown codelist code
-  case class Unknown(override val code: String) extends CodeListCode(code)
-
-  private val values: Set[CodeListCode]        = Set(BC08, BC66, CL141)
+  private val values: Set[CodeListCode]        = Set(BC08, BC36, BC66, CL141)
   private val codes: Map[String, CodeListCode] = values.map(value => value.code -> value).toMap
-  given Format[CodeListCode] = Format.of[String].bimap(codes.withDefault(Unknown.apply), _.code)
 
   def fromString(code: String): CodeListCode = codes.getOrElse(code, Unknown(code))
+
+  given Format[CodeListCode] = Format.of[String].bimap(codes.withDefault(Unknown.apply), _.code)
 
   given PathBindable[CodeListCode] = new PathBindable.Parsing[CodeListCode](
     value => codes.getOrElse(value, throw new IllegalArgumentException("Unknown code list code")),

--- a/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
@@ -21,11 +21,12 @@ import org.mongodb.scala.*
 import org.mongodb.scala.bson.BsonNull
 import org.mongodb.scala.model.*
 import org.mongodb.scala.model.Filters.*
+import play.api.libs.json.*
 import uk.gov.hmrc.crdlcache.models
 import uk.gov.hmrc.crdlcache.models.errors.MongoError
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry, Instruction}
 import uk.gov.hmrc.mongo.MongoComponent
-import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
 import uk.gov.hmrc.mongo.transaction.Transactions
 
 import java.time.Instant
@@ -40,12 +41,18 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
     mongoComponent,
     collectionName = "codelists",
     domainFormat = CodeListEntry.mongoFormat,
+    extraCodecs =
+      Codecs.playFormatSumCodecs[JsValue](Format(Reads.JsValueReads, Writes.jsValueWrites)) ++
+        Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)),
     indexes = Seq(
       IndexModel(
         Indexes.ascending("codeListCode", "key", "activeFrom"),
         IndexOptions().unique(true)
       ),
-      IndexModel(Indexes.ascending("activeTo"), IndexOptions().expireAfter(30, TimeUnit.DAYS))
+      IndexModel(
+        Indexes.ascending("activeTo"),
+        IndexOptions().expireAfter(30, TimeUnit.DAYS)
+      )
     )
   )
   with Transactions {
@@ -66,6 +73,7 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
   def fetchCodeListEntries(
     code: CodeListCode,
     filterKeys: Option[Set[String]],
+    filterProperties: Option[Map[String, JsValue]],
     activeAt: Instant
   ): Future[Seq[CodeListEntry]] = {
     val mandatoryFilters = List(
@@ -74,11 +82,19 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
       or(equal("activeTo", null), gt("activeTo", activeAt))
     )
 
-    val optionalFilters = filterKeys
+    val keyFilters = filterKeys
       .map(ks => if ks.nonEmpty then List(in("key", ks.toSeq*)) else List.empty)
       .getOrElse(List.empty)
 
-    val allFilters = mandatoryFilters ++ optionalFilters
+    val propertyFilters = filterProperties
+      .map { props =>
+        if props.nonEmpty
+        then props.map((k, v) => equal(s"properties.$k", v))
+        else List.empty
+      }
+      .getOrElse(List.empty)
+
+    val allFilters = mandatoryFilters ++ keyFilters ++ propertyFilters
 
     collection
       .find(and(allFilters*))
@@ -166,5 +182,4 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
           }
         }
     }
-
 }

--- a/app/uk/gov/hmrc/crdlcache/views/OpenApi.scala.html
+++ b/app/uk/gov/hmrc/crdlcache/views/OpenApi.scala.html
@@ -23,6 +23,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>CRDL Reference Data API @version</title>
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
   </head>
   <body>
     <redoc spec-url="@assets.path(s"api/$version/openapi.yaml")" disable-search="true"></redoc>

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,10 @@ lazy val microservice = Project("crdl-cache", file("."))
     ),
     routesImport ++= Seq(
       "java.time.Instant",
+      "play.api.libs.json.JsValue",
       "uk.gov.hmrc.crdlcache.models.*",
       "uk.gov.hmrc.crdlcache.models.Binders.bindableInstant",
+      "uk.gov.hmrc.crdlcache.models.Binders.bindableJsValueMap",
       "uk.gov.hmrc.crdlcache.models.Binders.bindableSet"
     ),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,3 @@
 # microservice specific routes
 
-GET        /lists/:code        uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListEntries(code: CodeListCode, keys: Option[Set[String]] ?= None, activeAt: Option[Instant])
+GET        /lists/:code        uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListEntries(code: CodeListCode, keys: Option[Set[String]] ?= None, properties: Option[Map[String, JsValue]] ?= None, activeAt: Option[Instant])

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -77,6 +77,11 @@ import-codelists {
       keyProperty = "CountryCode"
     }
     {
+      code = "BC36"
+      origin = "SEED"
+      keyProperty = "ExciseProductCode"
+    }
+    {
       code = "BC66"
       origin = "SEED"
       keyProperty = "ExciseProductsCategoryCode"

--- a/it/test/uk/gov/hmrc/crdlcache/controllers/CodeListsControllerSpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/controllers/CodeListsControllerSpec.scala
@@ -28,8 +28,8 @@ import play.api.Application
 import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.Json
-import uk.gov.hmrc.crdlcache.models.CodeListCode.BC08
+import play.api.libs.json.*
+import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, BC66}
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry}
 import uk.gov.hmrc.crdlcache.repositories.CodeListsRepository
 import uk.gov.hmrc.http.HttpReads.Implicits.*
@@ -96,7 +96,14 @@ class CodeListsControllerSpec
       .build()
 
   "CodeListsController" should "return 200 OK when there are no errors" in {
-    when(repository.fetchCodeListEntries(equalTo(BC08), equalTo(None), equalTo(fixedInstant)))
+    when(
+      repository.fetchCodeListEntries(
+        equalTo(BC08),
+        equalTo(None),
+        equalTo(None),
+        equalTo(fixedInstant)
+      )
+    )
       .thenReturn(Future.successful(entries))
 
     val response =
@@ -122,7 +129,14 @@ class CodeListsControllerSpec
   }
 
   it should "return 200 OK when there are no entries to return" in {
-    when(repository.fetchCodeListEntries(equalTo(BC08), equalTo(None), equalTo(fixedInstant)))
+    when(
+      repository.fetchCodeListEntries(
+        equalTo(BC08),
+        equalTo(None),
+        equalTo(None),
+        equalTo(fixedInstant)
+      )
+    )
       .thenReturn(Future.successful(List.empty))
 
     val response =
@@ -135,11 +149,12 @@ class CodeListsControllerSpec
     response.status mustBe Status.OK
   }
 
-  it should "parse comma-separated keys from a query parameter when there is only one key" in {
+  it should "parse comma-separated keys from the keys parameter when there is only one key" in {
     when(
       repository.fetchCodeListEntries(
         equalTo(BC08),
         equalTo(Some(Set("GB"))),
+        equalTo(None),
         equalTo(fixedInstant)
       )
     )
@@ -154,11 +169,12 @@ class CodeListsControllerSpec
     response.status mustBe Status.OK
   }
 
-  it should "parse comma-separated keys from a query parameter when there are multiple keys" in {
+  it should "parse comma-separated keys from the keys parameter when there are multiple keys" in {
     when(
       repository.fetchCodeListEntries(
         equalTo(BC08),
         equalTo(Some(Set("GB", "XI"))),
+        equalTo(None),
         equalTo(fixedInstant)
       )
     )
@@ -173,11 +189,12 @@ class CodeListsControllerSpec
     response.status mustBe Status.OK
   }
 
-  it should "parse comma-separated keys when there are multiple declarations of the query parameter" in {
+  it should "parse comma-separated keys when there are multiple declarations of the keys parameter" in {
     when(
       repository.fetchCodeListEntries(
         equalTo(BC08),
         equalTo(Some(Set("GB", "XI", "AW", "BL"))),
+        equalTo(None),
         equalTo(fixedInstant)
       )
     )
@@ -192,11 +209,12 @@ class CodeListsControllerSpec
     response.status mustBe Status.OK
   }
 
-  it should "parse comma-separated keys when there is no value declared for the query parameter" in {
+  it should "parse comma-separated keys when there is no value declared for the keys parameter" in {
     when(
       repository.fetchCodeListEntries(
         equalTo(BC08),
         equalTo(Some(Set.empty)),
+        equalTo(None),
         equalTo(fixedInstant)
       )
     )
@@ -205,6 +223,116 @@ class CodeListsControllerSpec
     val response =
       httpClientV2
         .get(url"http://localhost:$port/crdl-cache/lists/${BC08.code}?keys=")
+        .execute[HttpResponse]
+        .futureValue
+
+    response.status mustBe Status.OK
+  }
+
+  it should "parse other query parameters as boolean property filters when they are valid boolean values" in {
+    when(
+      repository.fetchCodeListEntries(
+        equalTo(BC66),
+        equalTo(Some(Set("B"))),
+        equalTo(Some(Map("isBeer" -> JsBoolean(true)))),
+        equalTo(fixedInstant)
+      )
+    )
+      .thenReturn(Future.successful(List.empty))
+
+    val response =
+      httpClientV2
+        .get(
+          url"http://localhost:$port/crdl-cache/lists/${BC66.code}?keys=B&isBeer=true"
+        )
+        .execute[HttpResponse]
+        .futureValue
+
+    response.status mustBe Status.OK
+  }
+
+  it should "parse other query parameters as null property filters when the query parameter value is null" in {
+    when(
+      repository.fetchCodeListEntries(
+        equalTo(BC66),
+        equalTo(Some(Set("B"))),
+        equalTo(Some(Map("isBeer" -> JsNull))),
+        equalTo(fixedInstant)
+      )
+    )
+      .thenReturn(Future.successful(List.empty))
+
+    val response =
+      httpClientV2
+        .get(
+          url"http://localhost:$port/crdl-cache/lists/${BC66.code}?keys=B&isBeer=null"
+        )
+        .execute[HttpResponse]
+        .futureValue
+
+    response.status mustBe Status.OK
+  }
+
+  it should "parse other query parameters as numeric property filters when they are valid numeric values" in {
+    when(
+      repository.fetchCodeListEntries(
+        equalTo(BC08),
+        equalTo(Some(Set("GB"))),
+        equalTo(Some(Map("actionIdentification" -> JsNumber(384)))),
+        equalTo(fixedInstant)
+      )
+    )
+      .thenReturn(Future.successful(List.empty))
+
+    val response =
+      httpClientV2
+        .get(
+          url"http://localhost:$port/crdl-cache/lists/${BC08.code}?keys=GB&actionIdentification=384"
+        )
+        .execute[HttpResponse]
+        .futureValue
+
+    response.status mustBe Status.OK
+  }
+
+  it should "parse other query parameters as String property filters when they are wrapped in quotes" in {
+    when(
+      repository.fetchCodeListEntries(
+        equalTo(BC08),
+        equalTo(Some(Set("GB"))),
+        equalTo(Some(Map("actionIdentification" -> JsString("384")))),
+        equalTo(fixedInstant)
+      )
+    )
+      .thenReturn(Future.successful(List.empty))
+
+    val response =
+      httpClientV2
+        .get(
+          url"http://localhost:$port/crdl-cache/lists/${BC08.code}?keys=GB&actionIdentification=%22384%22"
+        )
+        .execute[HttpResponse]
+        .futureValue
+
+    response.status mustBe Status.OK
+  }
+
+  it should "parse other query parameters as String property filters when they cannot be any other valid JSON value" in {
+    when(
+      repository.fetchCodeListEntries(
+        equalTo(BC66),
+        equalTo(Some(Set("B"))),
+        equalTo(Some(Map("responsibleDataManager" -> JsString("ABC")))),
+        equalTo(fixedInstant)
+      )
+    )
+      .thenReturn(Future.successful(List.empty))
+
+    val response =
+      httpClientV2
+        .get(
+          url"http://localhost:$port/crdl-cache/lists/${BC66.code}?keys=B&responsibleDataManager=ABC"
+        )
         .execute[HttpResponse]
         .futureValue
 
@@ -234,7 +362,14 @@ class CodeListsControllerSpec
   }
 
   it should "return 500 Internal Server Error when there is an error fetching from the repository" in {
-    when(repository.fetchCodeListEntries(equalTo(BC08), equalTo(None), equalTo(fixedInstant)))
+    when(
+      repository.fetchCodeListEntries(
+        equalTo(BC08),
+        equalTo(None),
+        equalTo(None),
+        equalTo(fixedInstant)
+      )
+    )
       .thenReturn(Future.failed(new RuntimeException("Boom!!!")))
 
     val response =

--- a/it/test/uk/gov/hmrc/crdlcache/controllers/CodeListsControllerSpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/controllers/CodeListsControllerSpec.scala
@@ -29,7 +29,7 @@ import play.api.http.Status
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.*
-import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, BC66}
+import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, BC36, BC66}
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry}
 import uk.gov.hmrc.crdlcache.repositories.CodeListsRepository
 import uk.gov.hmrc.http.HttpReads.Implicits.*
@@ -232,9 +232,9 @@ class CodeListsControllerSpec
   it should "parse other query parameters as boolean property filters when they are valid boolean values" in {
     when(
       repository.fetchCodeListEntries(
-        equalTo(BC66),
-        equalTo(Some(Set("B"))),
-        equalTo(Some(Map("isBeer" -> JsBoolean(true)))),
+        equalTo(BC36),
+        equalTo(Some(Set("B000"))),
+        equalTo(Some(Map("alcoholicStrengthApplicabilityFlag" -> JsBoolean(true)))),
         equalTo(fixedInstant)
       )
     )
@@ -243,7 +243,7 @@ class CodeListsControllerSpec
     val response =
       httpClientV2
         .get(
-          url"http://localhost:$port/crdl-cache/lists/${BC66.code}?keys=B&isBeer=true"
+          url"http://localhost:$port/crdl-cache/lists/${BC36.code}?keys=B000&alcoholicStrengthApplicabilityFlag=true"
         )
         .execute[HttpResponse]
         .futureValue
@@ -256,7 +256,7 @@ class CodeListsControllerSpec
       repository.fetchCodeListEntries(
         equalTo(BC66),
         equalTo(Some(Set("B"))),
-        equalTo(Some(Map("isBeer" -> JsNull))),
+        equalTo(Some(Map("responsibleDataManager" -> JsNull))),
         equalTo(fixedInstant)
       )
     )
@@ -265,7 +265,7 @@ class CodeListsControllerSpec
     val response =
       httpClientV2
         .get(
-          url"http://localhost:$port/crdl-cache/lists/${BC66.code}?keys=B&isBeer=null"
+          url"http://localhost:$port/crdl-cache/lists/${BC66.code}?keys=B&responsibleDataManager=null"
         )
         .execute[HttpResponse]
         .futureValue
@@ -273,29 +273,7 @@ class CodeListsControllerSpec
     response.status mustBe Status.OK
   }
 
-  it should "parse other query parameters as numeric property filters when they are valid numeric values" in {
-    when(
-      repository.fetchCodeListEntries(
-        equalTo(BC08),
-        equalTo(Some(Set("GB"))),
-        equalTo(Some(Map("actionIdentification" -> JsNumber(384)))),
-        equalTo(fixedInstant)
-      )
-    )
-      .thenReturn(Future.successful(List.empty))
-
-    val response =
-      httpClientV2
-        .get(
-          url"http://localhost:$port/crdl-cache/lists/${BC08.code}?keys=GB&actionIdentification=384"
-        )
-        .execute[HttpResponse]
-        .futureValue
-
-    response.status mustBe Status.OK
-  }
-
-  it should "parse other query parameters as String property filters when they are wrapped in quotes" in {
+  it should "parse other query parameters as String property filters when they are neither boolean nor null values" in {
     when(
       repository.fetchCodeListEntries(
         equalTo(BC08),
@@ -309,29 +287,7 @@ class CodeListsControllerSpec
     val response =
       httpClientV2
         .get(
-          url"http://localhost:$port/crdl-cache/lists/${BC08.code}?keys=GB&actionIdentification=%22384%22"
-        )
-        .execute[HttpResponse]
-        .futureValue
-
-    response.status mustBe Status.OK
-  }
-
-  it should "parse other query parameters as String property filters when they cannot be any other valid JSON value" in {
-    when(
-      repository.fetchCodeListEntries(
-        equalTo(BC66),
-        equalTo(Some(Set("B"))),
-        equalTo(Some(Map("responsibleDataManager" -> JsString("ABC")))),
-        equalTo(fixedInstant)
-      )
-    )
-      .thenReturn(Future.successful(List.empty))
-
-    val response =
-      httpClientV2
-        .get(
-          url"http://localhost:$port/crdl-cache/lists/${BC66.code}?keys=B&responsibleDataManager=ABC"
+          url"http://localhost:$port/crdl-cache/lists/${BC08.code}?keys=GB&actionIdentification=384"
         )
         .execute[HttpResponse]
         .futureValue

--- a/it/test/uk/gov/hmrc/crdlcache/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/repositories/CodeListsRepositorySpec.scala
@@ -23,8 +23,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.{Assertion, OptionValues}
-import play.api.libs.json.Json
-import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, BC66}
+import play.api.libs.json.{JsNull, JsString, JsTrue, Json}
+import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, BC36, BC66}
 import uk.gov.hmrc.crdlcache.models.CodeListEntry
 import uk.gov.hmrc.crdlcache.models.Instruction.{InvalidateEntry, RecordMissingEntry, UpsertEntry}
 import uk.gov.hmrc.mongo.test.{
@@ -241,11 +241,12 @@ class CodeListsRepositorySpec
       .fetchCodeListEntries(
         BC08,
         filterKeys = None,
+        filterProperties = None,
         activeAt = Instant.parse("2025-06-05T00:00:00Z")
       )
       .map(_ must contain allElementsOf activeCodelistEntries)
   }
-  
+
   it should "apply filtering of entries according to the supplied keys" in withCodeListEntries(
     codelistEntries
   ) { _ =>
@@ -253,6 +254,7 @@ class CodeListsRepositorySpec
       .fetchCodeListEntries(
         BC08,
         filterKeys = Some(Set("AW", "BL")),
+        filterProperties = None,
         activeAt = Instant.parse("2025-06-05T00:00:00Z")
       )
       .map(_ must contain allElementsOf activeCodelistEntries.take(2))
@@ -265,6 +267,7 @@ class CodeListsRepositorySpec
       .fetchCodeListEntries(
         BC08,
         filterKeys = Some(Set.empty),
+        filterProperties = None,
         activeAt = Instant.parse("2025-06-05T00:00:00Z")
       )
       .map(_ must contain allElementsOf activeCodelistEntries)
@@ -275,6 +278,7 @@ class CodeListsRepositorySpec
       .fetchCodeListEntries(
         BC08,
         filterKeys = None,
+        filterProperties = None,
         activeAt = Instant.parse("2025-06-05T00:00:00Z")
       )
       .map(_ must contain noElementsOf differentCodeListEntries)
@@ -287,28 +291,34 @@ class CodeListsRepositorySpec
       .fetchCodeListEntries(
         BC08,
         filterKeys = Some(Set("B")),
+        filterProperties = None,
         activeAt = Instant.parse("2025-06-05T00:00:00Z")
       )
       .map(_ must contain noElementsOf differentCodeListEntries)
   }
 
-  it should "not return entries that have been superseded" in withCodeListEntries(codelistEntries) { _ =>
-    repository
-      .fetchCodeListEntries(
-        BC08,
-        filterKeys = None,
-        activeAt = Instant.parse("2025-06-05T00:00:00Z"))
-      .map(_ must contain noElementsOf supersededCodeListEntries)
+  it should "not return entries that have been superseded" in withCodeListEntries(codelistEntries) {
+    _ =>
+      repository
+        .fetchCodeListEntries(
+          BC08,
+          filterKeys = None,
+          filterProperties = None,
+          activeAt = Instant.parse("2025-06-05T00:00:00Z")
+        )
+        .map(_ must contain noElementsOf supersededCodeListEntries)
   }
 
-  it should "not return entries that are not yet active" in withCodeListEntries(codelistEntries) { _ =>
-    repository
-      .fetchCodeListEntries(
-        BC08,
-        filterKeys = None,
-        activeAt = Instant.parse("2025-06-05T00:00:00Z")
-      )
-      .map(_ mustNot contain(postDatedEntry))
+  it should "not return entries that are not yet active" in withCodeListEntries(codelistEntries) {
+    _ =>
+      repository
+        .fetchCodeListEntries(
+          BC08,
+          filterKeys = None,
+          filterProperties = None,
+          activeAt = Instant.parse("2025-06-05T00:00:00Z")
+        )
+        .map(_ mustNot contain(postDatedEntry))
   }
 
   it should "return entries that have been invalidated if the invalidation date is in the future" in withCodeListEntries(
@@ -318,9 +328,123 @@ class CodeListsRepositorySpec
       .fetchCodeListEntries(
         BC08,
         filterKeys = None,
+        filterProperties = None,
         activeAt = Instant.parse("2025-06-05T00:00:00Z")
       )
       .map(_ must contain(invalidatedIoEntry))
+  }
+
+  private val exciseProductEntries = Seq(
+    CodeListEntry(
+      BC36,
+      "B000",
+      "Beer",
+      Instant.parse("2018-01-16T00:00:00Z"),
+      None,
+      Some(Instant.parse("2018-01-15T00:00:00Z")),
+      Json.obj(
+        "exciseProductsCategoryCode"         -> "B",
+        "unitOfMeasureCode"                  -> "3",
+        "alcoholicStrengthApplicabilityFlag" -> true,
+        "degreePlatoApplicabilityFlag"       -> true,
+        "densityApplicabilityFlag"           -> false,
+        "responsibleDataManager"             -> null
+      )
+    ),
+    CodeListEntry(
+      BC36,
+      "E200",
+      "Vegetable and animal oils Products falling within CN codes 1507 to 1518, if these are intended for use a\ns heating fuel or motor fuel (Article 20(1)(a))",
+      Instant.parse("2022-05-15T00:00:00Z"),
+      None,
+      Some(Instant.parse("2022-05-13T00:00:00Z")),
+      Json.obj(
+        "exciseProductsCategoryCode"         -> "E",
+        "unitOfMeasureCode"                  -> "2",
+        "alcoholicStrengthApplicabilityFlag" -> false,
+        "degreePlatoApplicabilityFlag"       -> false,
+        "densityApplicabilityFlag"           -> true
+      )
+    ),
+    CodeListEntry(
+      BC36,
+      "W200",
+      "Still wine and still fermented beverages other than wine and beer",
+      Instant.parse("2023-11-02T00:00:00Z"),
+      None,
+      Some(Instant.parse("2023-11-01T00:00:00Z")),
+      Json.obj(
+        "exciseProductsCategoryCode"         -> "W",
+        "unitOfMeasureCode"                  -> "3",
+        "alcoholicStrengthApplicabilityFlag" -> true,
+        "degreePlatoApplicabilityFlag"       -> false,
+        "densityApplicabilityFlag"           -> false,
+        "responsibleDataManager"             -> "ABC"
+      )
+    )
+  )
+
+  it should "apply filtering of entries using String properties" in withCodeListEntries(
+    exciseProductEntries
+  ) { _ =>
+    repository
+      .fetchCodeListEntries(
+        BC36,
+        filterKeys = Some(Set("B000", "W200")),
+        filterProperties = Some(Map("exciseProductsCategoryCode" -> JsString("W"))),
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .map(_ must contain only exciseProductEntries.last)
+  }
+
+  it should "apply filtering of entries using Boolean properties" in withCodeListEntries(
+    exciseProductEntries
+  ) { _ =>
+    for {
+      allEntriesWithFlag <- repository
+        .fetchCodeListEntries(
+          BC36,
+          filterKeys = None,
+          filterProperties = Some(Map("alcoholicStrengthApplicabilityFlag" -> JsTrue)),
+          activeAt = Instant.parse("2025-06-05T00:00:00Z")
+        )
+
+      filteredEntriesWithFlag <- repository
+        .fetchCodeListEntries(
+          BC36,
+          filterKeys = Some(Set("B000", "W200")),
+          filterProperties = Some(Map("degreePlatoApplicabilityFlag" -> JsTrue)),
+          activeAt = Instant.parse("2025-06-05T00:00:00Z")
+        )
+    } yield {
+      allEntriesWithFlag must contain allOf (exciseProductEntries.head, exciseProductEntries.last)
+      filteredEntriesWithFlag must contain only exciseProductEntries.head
+    }
+  }
+
+  it should "apply filtering of entries using null or missing values" in withCodeListEntries(
+    exciseProductEntries
+  ) { _ =>
+    for {
+      allEntriesWithNull <- repository
+        .fetchCodeListEntries(
+          BC36,
+          filterKeys = None,
+          filterProperties = Some(Map("responsibleDataManager" -> JsNull)),
+          activeAt = Instant.parse("2025-06-05T00:00:00Z")
+        )
+
+      filteredEntriesWithNull <- repository
+        .fetchCodeListEntries(
+          BC36,
+          filterKeys = Some(Set("B000", "W200")),
+          filterProperties = Some(Map("responsibleDataManager" -> JsNull)),
+          activeAt = Instant.parse("2025-06-05T00:00:00Z")
+        )
+    } yield {
+      allEntriesWithNull must contain allElementsOf exciseProductEntries.init
+      filteredEntriesWithNull must contain only exciseProductEntries.head
+    }
   }
 
   "CodeListsRepository.executeInstructions" should "invalidate existing entries" in withCodeListEntries(

--- a/public/api/1.0/openapi.yaml
+++ b/public/api/1.0/openapi.yaml
@@ -89,10 +89,15 @@ paths:
           explode: true
           schema:
             type: object
+            patternProperties:
+              "Flag$":
+                type: boolean
+            additionalProperties:
+              type: [ "string", "null" ]
             examples:
               - unitOfMeasureCode: "3"
               - alcoholicStrengthApplicabilityFlag: true
-              - responsibleDataManager: "null"
+              - responsibleDataManager: null
         # The `activeAt` parameter is undocumented for now as we await historical data bugfixes at DPS
         # - name: activeAt
         #   in: query
@@ -132,8 +137,15 @@ paths:
                     properties:
                       type: object
                       description: Feed-specific and codelist-specific properties.
+                      patternProperties:
+                        "Flag$":
+                          type: boolean
+                      additionalProperties:
+                        type: [ "string", "null" ]
                       examples:
                         - actionIdentification: "823"
+                          responsibleDataManager: null
+                          memberStateFlag: false
 
         400:
           $ref: "#/components/responses/badRequest"

--- a/public/api/1.0/openapi.yaml
+++ b/public/api/1.0/openapi.yaml
@@ -16,11 +16,57 @@ servers:
   - url: https://crdl-cache.protected.mdtp/crdl-cache
     description: MDTP
 
+tags:
+  - name: Codelists
+    description: |
+      These endpoints provide operations for working with reference data codelists.
+      
+      Reference data codelists usually have a key-value structure, but in some cases they may have additional useful properties.
+      
+      For example, entries in the excise products codelist (BC36) contain properties describing the excise product category
+      they belong to, and applicability flags describing which kinds of excise information apply to that particular product.
+
 components:
+  schemas:
+    CodeListEntry:
+      type: object
+      x-tags:
+        - Codelists
+      required:
+        - key
+        - value
+        - properties
+      additionalProperties: false
+      properties:
+        key:
+          type: string
+          description: The unique key of the codelist entry.
+        value:
+          type: string
+          description: The description of the codelist entry.
+        properties:
+          type: object
+          description: Feed-specific and codelist-specific properties.
+          patternProperties:
+            "Flag$":
+              type: boolean
+          additionalProperties:
+            type: [ "string", "null" ]
+      examples:
+        - key: BM
+          value: Bermuda
+          properties:
+            actionIdentification: "824"
+  
   responses:
     badRequest:
-      description: Bad Request
-      summary: |
+      x-summary: Bad Request
+      description: |
+        This error is returned when invalid path parameter or query parameter values are used.
+
+        Unfortunately the [JsonErrorHandler](https://github.com/hmrc/bootstrap-play/blob/466657a13dec046a94ace9d3138dde33bead82e3/bootstrap-backend-play-30/src/main/scala/uk/gov/hmrc/play/bootstrap/backend/http/JsonErrorHandler.scala) of [bootstrap-play](https://github.com/hmrc/bootstrap-play) unconditionally redacts anything which looks like a parameter parsing error.
+
+        We can implement our own error handler if this proves excessively unhelpful to consuming services.
       content:
         application/json:
           schema:
@@ -38,7 +84,7 @@ components:
                   - 400
               message:
                 type: string
-                description: The message indicating the cause of the bad request status.
+                description: A message indicating the cause of the bad request status.
                 examples:
                   - "bad request, cause: REDACTED"
 
@@ -48,6 +94,8 @@ paths:
       summary: Fetch Codelist Entries
       description: |
         This endpoint is used to fetch entries of a reference data codelist.
+      tags:
+        - Codelists
       parameters:
         - name: code
           in: path
@@ -80,7 +128,7 @@ paths:
         - name: properties
           in: query
           description: |
-            Used to specify property values used to filter entries in the response.
+            Used to filter entries by the feed-specific and codelist-specific properties in the `properties` object.
             
             **Note:** This API allows any query parameter name to be used for filtering feed-specific and codelist-specific properties. You do not need to prefix the query parameter with `properties`.
             
@@ -117,35 +165,35 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  required:
-                    - key
-                    - value
-                    - properties
-                  additionalProperties: false
-                  properties:
-                    key:
-                      type: string
-                      description: The unique key of the codelist entry.
-                      examples:
-                        - BM
-                    value:
-                      type: string
-                      description: The description of the codelist entry.
-                      examples:
-                        - Bermuda
-                    properties:
-                      type: object
-                      description: Feed-specific and codelist-specific properties.
-                      patternProperties:
-                        "Flag$":
-                          type: boolean
-                      additionalProperties:
-                        type: [ "string", "null" ]
-                      examples:
-                        - actionIdentification: "823"
-                          responsibleDataManager: null
-                          memberStateFlag: false
+                  $ref: "#/components/schemas/CodeListEntry"
+                examples:
+                  - - key: B000
+                      value: Beer
+                      properties:
+                        actionIdentification: "1087"
+                        exciseProductsCategoryCode: "B"
+                        unitOfMeasureCode: "3"
+                        alcoholicStrengthApplicabilityFlag: true
+                        degreePlatoApplicabilityFlag: true
+                        densityApplicabilityFlag: false
+                    - key: E200
+                      value: Vegetable and animal oils Products falling within CN codes 1507 to 1518, if these are intended for use as heating fuel or motor fuel (Article 20(1)(a))
+                      properties:
+                        actionIdentification: "1088"
+                        exciseProductsCategoryCode: "E"
+                        unitOfMeasureCode: "2"
+                        alcoholicStrengthApplicabilityFlag: false
+                        degreePlatoApplicabilityFlag: false
+                        densityApplicabilityFlag: true
+                    - key: W200
+                      value: Still wine and still fermented beverages other than wine and beer
+                      properties:
+                        actionIdentification: "1116"
+                        exciseProductsCategoryCode: "W"
+                        unitOfMeasureCode: "3"
+                        alcoholicStrengthApplicabilityFlag: true
+                        degreePlatoApplicabilityFlag: false
+                        densityApplicabilityFlag: false
 
         400:
           $ref: "#/components/responses/badRequest"

--- a/public/api/1.0/openapi.yaml
+++ b/public/api/1.0/openapi.yaml
@@ -97,7 +97,7 @@ paths:
             examples:
               - unitOfMeasureCode: "3"
               - alcoholicStrengthApplicabilityFlag: true
-              - responsibleDataManager: null
+              - responsibleDataManager: "null"
         # The `activeAt` parameter is undocumented for now as we await historical data bugfixes at DPS
         # - name: activeAt
         #   in: query

--- a/public/api/1.0/openapi.yaml
+++ b/public/api/1.0/openapi.yaml
@@ -64,6 +64,10 @@ paths:
           in: query
           description: |
             Used to specify the keys of entries to return in the response.
+            
+            You can provide comma-separated values for keys, or provide multiple occurrences of the `keys` parameter, or both.
+            
+            For example: `?keys=AW,BL&keys=XI&keys=GB`.
           required: false
           schema:
             type: array
@@ -73,6 +77,22 @@ paths:
               examples:
                 - [ "GB", "XI" ]
                 - [ "B000", "E200" ]
+        - name: properties
+          in: query
+          description: |
+            Used to specify property values used to filter entries in the response.
+            
+            **Note:** This API allows any query parameter name to be used for filtering feed-specific and codelist-specific properties. You do not need to prefix the query parameter with `properties`.
+            
+            For example: `?unitOfMeasureCode=3&responsibleDataManager=null`.
+          required: false
+          explode: true
+          schema:
+            type: object
+            examples:
+              - unitOfMeasureCode: "3"
+              - alcoholicStrengthApplicabilityFlag: true
+              - responsibleDataManager: "null"
         # The `activeAt` parameter is undocumented for now as we await historical data bugfixes at DPS
         # - name: activeAt
         #   in: query

--- a/test/uk/gov/hmrc/crdlcache/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/config/AppConfigSpec.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.Configuration
-import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, Unknown}
+import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, BC36, Unknown}
 import uk.gov.hmrc.crdlcache.models.CodeListOrigin.SEED
 
 import java.time.LocalDate
@@ -39,7 +39,8 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
         "import-codelists.last-updated-date.default" -> "2025-05-29",
         "import-codelists.codelists" -> List(
           Map("code" -> "BC08", "origin" -> "SEED", "keyProperty" -> "CountryCode"),
-          Map("code" -> "BC36", "origin" -> "SEED", "keyProperty" -> "ExciseProductCode")
+          Map("code" -> "BC36", "origin" -> "SEED", "keyProperty" -> "ExciseProductCode"),
+          Map("code" -> "BC17", "origin" -> "SEED", "keyProperty" -> "KindOfPackages")
         )
       )
     )
@@ -55,7 +56,8 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
     appConfig.defaultLastUpdated mustBe LocalDate.of(2025, 5, 29)
     appConfig.codeListConfigs mustBe List(
       CodeListConfig(BC08, SEED, "CountryCode"),
-      CodeListConfig(Unknown("BC36"), SEED, "ExciseProductCode")
+      CodeListConfig(BC36, SEED, "ExciseProductCode"),
+      CodeListConfig(Unknown("BC17"), SEED, "KindOfPackages")
     )
   }
 

--- a/test/uk/gov/hmrc/crdlcache/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/config/AppConfigSpec.scala
@@ -74,6 +74,7 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
     appConfig.defaultLastUpdated mustBe LocalDate.of(2025, 3, 12)
     appConfig.codeListConfigs mustBe List(
       CodeListConfig(BC08, SEED, "CountryCode"),
+      CodeListConfig(BC36, SEED, "ExciseProductCode"),
       CodeListConfig(BC66, SEED, "ExciseProductsCategoryCode")
     )
   }

--- a/test/uk/gov/hmrc/crdlcache/controllers/documentation/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/controllers/documentation/DocumentationControllerSpec.scala
@@ -45,6 +45,7 @@ class DocumentationControllerSpec extends AnyFlatSpec with Matchers with Mockito
         |    <meta charset="UTF-8">
         |    <meta name="viewport" content="width=device-width, initial-scale=1">
         |    <title>CRDL Reference Data API 1.0</title>
+        |    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
         |  </head>
         |  <body>
         |    <redoc spec-url="/api/1.0/openapi.yaml" disable-search="true"></redoc>

--- a/test/uk/gov/hmrc/crdlcache/models/BindersSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/models/BindersSpec.scala
@@ -105,8 +105,9 @@ class BindersSpec
     Binders.bindableJsValueMap.bind(
       "",
       Map(
-        // "keys" should be ignored in the output
+        // "keys" and "activeAt" should be ignored in the output
         "keys"                         -> Seq("GB,XI"),
+        "activeAt"                     -> Seq("2025-06-05T00:00:00Z"),
         "degreePlatoApplicabilityFlag" -> Seq("true"),
         "responsibleDataManager"       -> Seq("null"),
         "actionIdentification"         -> Seq("823"),


### PR DESCRIPTION
This PR adds filtering of codelist entries by properties to the Fetch Codelist Entries endpoint.

This can be done by providing query parameters other than `keys` and `activeAt`, e.g.

`/crdl-cache/lists/BC36?densityApplicabilityFlag=true`
`/crdl-cache/lists/BC36?unitOfMeasureCode=3`
`/crdl-cache/lists/BC36?responsibleDataManager=null`
`/crdl-cache/lists/BC36?exciseProductCategoryCode=W`
