### PR TITLE
Disable the JUnit XML plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ ThisBuild / scalaVersion := "3.3.6"
 
 lazy val microservice = Project("crdl-cache", file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
+  .disablePlugins(JUnitXmlReportPlugin)
   .settings(CodeCoverageSettings.settings *)
   .settings(
     PlayKeys.playDefaultPort := 7252,
@@ -26,6 +27,7 @@ lazy val microservice = Project("crdl-cache", file("."))
 
 lazy val it = project
   .enablePlugins(PlayScala)
+  .disablePlugins(JUnitXmlReportPlugin)
   .dependsOn(microservice % "test->test")
   .settings(DefaultBuildSettings.itSettings())
   .settings(


### PR DESCRIPTION
Averts build stability issues caused by https://github.com/scalatest/scalatest/issues/1427 / https://github.com/playframework/playframework/issues/10000 / https://github.com/sbt/sbt/pull/4343. 