### PR TITLE
CRDL-345 Add a correspondence lists repository for the E200 codelist

### DIFF
--- a/app/uk/gov/hmrc/crdlcache/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/crdlcache/config/AppConfig.scala
@@ -37,9 +37,11 @@ class AppConfig @Inject() (val config: Configuration) extends ServicesConfig(con
 
   val importCodeListsSchedule: String = config.get[String]("import-codelists.schedule")
   val importOfficesSchedule: String   = config.get[String]("import-offices.schedule")
+  val importCorrespondenceListsSchedule: String =
+    config.get[String]("import-correspondence-lists.schedule")
 
   val defaultLastUpdated: LocalDate =
-    LocalDate.parse(config.get[String]("import-codelists.last-updated-date.default"))
+    LocalDate.parse(config.get[String]("last-updated-date.default"))
 
   val codeListConfigs: List[CodeListConfig] =
     config
@@ -49,6 +51,19 @@ class AppConfig @Inject() (val config: Configuration) extends ServicesConfig(con
           CodeListCode.fromString(codeListConfig.getString("code")),
           CodeListOrigin.valueOf(codeListConfig.getString("origin")),
           codeListConfig.getString("keyProperty")
+        )
+      }
+      .toList
+
+  val correspondenceListConfigs: List[CorrespondenceListConfig] =
+    config
+      .get[Seq[Config]]("import-correspondence-lists.correspondence-lists")
+      .map { codeListConfig =>
+        CorrespondenceListConfig(
+          CodeListCode.fromString(codeListConfig.getString("code")),
+          CodeListOrigin.valueOf(codeListConfig.getString("origin")),
+          codeListConfig.getString("keyProperty"),
+          codeListConfig.getString("valueProperty")
         )
       }
       .toList

--- a/app/uk/gov/hmrc/crdlcache/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/crdlcache/config/AppConfig.scala
@@ -58,12 +58,12 @@ class AppConfig @Inject() (val config: Configuration) extends ServicesConfig(con
   val correspondenceListConfigs: List[CorrespondenceListConfig] =
     config
       .get[Seq[Config]]("import-correspondence-lists.correspondence-lists")
-      .map { codeListConfig =>
+      .map { correspondenceListConfig =>
         CorrespondenceListConfig(
-          CodeListCode.fromString(codeListConfig.getString("code")),
-          CodeListOrigin.valueOf(codeListConfig.getString("origin")),
-          codeListConfig.getString("keyProperty"),
-          codeListConfig.getString("valueProperty")
+          CodeListCode.fromString(correspondenceListConfig.getString("code")),
+          CodeListOrigin.valueOf(correspondenceListConfig.getString("origin")),
+          correspondenceListConfig.getString("keyProperty"),
+          correspondenceListConfig.getString("valueProperty")
         )
       }
       .toList

--- a/app/uk/gov/hmrc/crdlcache/config/CorrespondenceListConfig.scala
+++ b/app/uk/gov/hmrc/crdlcache/config/CorrespondenceListConfig.scala
@@ -18,5 +18,9 @@ package uk.gov.hmrc.crdlcache.config
 
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListOrigin}
 
-case class CodeListConfig(code: CodeListCode, origin: CodeListOrigin, keyProperty: String)
-  extends ListConfig
+case class CorrespondenceListConfig(
+  code: CodeListCode,
+  origin: CodeListOrigin,
+  keyProperty: String,
+  valueProperty: String
+) extends ListConfig

--- a/app/uk/gov/hmrc/crdlcache/config/ListConfig.scala
+++ b/app/uk/gov/hmrc/crdlcache/config/ListConfig.scala
@@ -18,5 +18,8 @@ package uk.gov.hmrc.crdlcache.config
 
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListOrigin}
 
-case class CodeListConfig(code: CodeListCode, origin: CodeListOrigin, keyProperty: String)
-  extends ListConfig
+trait ListConfig {
+  def code: CodeListCode
+  def origin: CodeListOrigin
+  def keyProperty: String
+}

--- a/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
@@ -21,9 +21,9 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.crdlcache.models.CodeListType.{CORRESPONDENCE, STANDARD}
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry}
 import uk.gov.hmrc.crdlcache.repositories.{
-  CodeListsRepository,
   CorrespondenceListsRepository,
-  LastUpdatedRepository
+  LastUpdatedRepository,
+  StandardCodeListsRepository
 }
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
@@ -34,7 +34,7 @@ import scala.concurrent.ExecutionContext
 @Singleton()
 class CodeListsController @Inject() (
   cc: ControllerComponents,
-  codeListsRepository: CodeListsRepository,
+  codeListsRepository: StandardCodeListsRepository,
   correspondenceListsRepository: CorrespondenceListsRepository,
   lastUpdatedRepository: LastUpdatedRepository,
   clock: Clock
@@ -50,7 +50,7 @@ class CodeListsController @Inject() (
     val codeListEntries = codeListCode.listType match {
       case STANDARD =>
         codeListsRepository
-          .fetchCodeListEntries(
+          .fetchEntries(
             codeListCode,
             filterKeys,
             filterProperties,
@@ -58,7 +58,7 @@ class CodeListsController @Inject() (
           )
       case CORRESPONDENCE =>
         correspondenceListsRepository
-          .fetchCorrespondenceListEntries(
+          .fetchEntries(
             codeListCode,
             filterKeys,
             filterProperties,

--- a/app/uk/gov/hmrc/crdlcache/controllers/testonly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/testonly/TestOnlyController.scala
@@ -55,6 +55,10 @@ class TestOnlyController @Inject() (
     Accepted
   }
 
+  def correspondenceListImportStatus(): Action[AnyContent] = Action {
+    Ok(Json.toJson(jobScheduler.codeListImportStatus()))
+  }
+
   def deleteCodeLists(): Action[AnyContent] = Action.async {
     codeListsRepository.collection.deleteMany(Filters.empty()).toFuture().map {
       case result if result.wasAcknowledged() => Ok

--- a/app/uk/gov/hmrc/crdlcache/controllers/testonly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/testonly/TestOnlyController.scala
@@ -20,9 +20,9 @@ import org.mongodb.scala.*
 import org.mongodb.scala.model.Filters
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.crdlcache.repositories.{
-  CodeListsRepository,
   CorrespondenceListsRepository,
-  LastUpdatedRepository
+  LastUpdatedRepository,
+  StandardCodeListsRepository
 }
 import uk.gov.hmrc.crdlcache.schedulers.JobScheduler
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
@@ -35,7 +35,7 @@ class TestOnlyController @Inject() (
   cc: ControllerComponents,
   jobScheduler: JobScheduler,
   lastUpdatedRepository: LastUpdatedRepository,
-  codeListsRepository: CodeListsRepository,
+  codeListsRepository: StandardCodeListsRepository,
   correspondenceListsRepository: CorrespondenceListsRepository
 )(using ec: ExecutionContext)
   extends BackendController(cc) {

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListCode.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListCode.scala
@@ -18,8 +18,9 @@ package uk.gov.hmrc.crdlcache.models
 
 import play.api.libs.json.Format
 import play.api.mvc.PathBindable
+import uk.gov.hmrc.crdlcache.models.CodeListType.{CORRESPONDENCE, STANDARD}
 
-enum CodeListCode(val code: String) {
+enum CodeListCode(val code: String, val listType: CodeListType = STANDARD) {
   // BC01 (Evidence Types)
   case BC01 extends CodeListCode("BC01")
   // BC03 (Reasons for action not possible)
@@ -79,7 +80,7 @@ enum CodeListCode(val code: String) {
   // CL141 (Customs Offices)
   case CL141 extends CodeListCode("CL141")
   // E200 (CN Code <-> Excise Products Correspondence)
-  case E200 extends CodeListCode("E200")
+  case E200 extends CodeListCode("E200", listType = CORRESPONDENCE)
   // Unknown codelist code
   case Unknown(override val code: String) extends CodeListCode(code)
 }

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListCode.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListCode.scala
@@ -78,6 +78,8 @@ enum CodeListCode(val code: String) {
   case BC109 extends CodeListCode("BC109")
   // CL141 (Customs Offices)
   case CL141 extends CodeListCode("CL141")
+  // E200 (CN Code <-> Excise Products Correspondence)
+  case E200 extends CodeListCode("E200")
   // Unknown codelist code
   case Unknown(override val code: String) extends CodeListCode(code)
 }
@@ -113,7 +115,8 @@ object CodeListCode {
       BC107,
       BC108,
       BC109,
-      CL141
+      CL141,
+      E200
     )
 
   private val codes: Map[String, CodeListCode] = values.map(value => value.code -> value).toMap

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListEntry.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListEntry.scala
@@ -32,13 +32,15 @@ case class CodeListEntry(
 )
 
 object CodeListEntry {
+  given Reads[CodeListEntry] = Json.reads[CodeListEntry]
+
   // Only serialize the key, value and properties in JSON responses
   given Writes[CodeListEntry] = (
     (JsPath \ "key").write[String] and
       (JsPath \ "value").write[String] and
       (JsPath \ "properties").write[JsObject]
   )(entry => (entry.key, entry.value, entry.properties))
-
+  
   // Serialize the full object in MongoDB
   val mongoFormat: Format[CodeListEntry] = {
     // Use the Mongo Extended JSON format for dates

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListSnapshot.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListSnapshot.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.crdlcache.models
 
-import uk.gov.hmrc.crdlcache.config.CodeListConfig
+import uk.gov.hmrc.crdlcache.config.{CodeListConfig, CorrespondenceListConfig, ListConfig}
 import uk.gov.hmrc.crdlcache.models.dps.codeList
 
 case class CodeListSnapshot(
@@ -28,7 +28,7 @@ case class CodeListSnapshot(
 
 object CodeListSnapshot {
   def fromDpsSnapshot(
-    config: CodeListConfig,
+    config: ListConfig,
     dpsSnapshot: codeList.CodeListSnapshot
   ): CodeListSnapshot = {
     CodeListSnapshot(

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListSnapshot.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListSnapshot.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.crdlcache.models
 
-import uk.gov.hmrc.crdlcache.config.{CodeListConfig, CorrespondenceListConfig, ListConfig}
+import uk.gov.hmrc.crdlcache.config.ListConfig
 import uk.gov.hmrc.crdlcache.models.dps.codeList
 
 case class CodeListSnapshot(

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListSnapshotEntry.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListSnapshotEntry.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.crdlcache.models
 
 import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json.{JsObject, Json}
-import uk.gov.hmrc.crdlcache.config.CodeListConfig
+import uk.gov.hmrc.crdlcache.config.{CodeListConfig, CorrespondenceListConfig, ListConfig}
 import uk.gov.hmrc.crdlcache.models.CodeListOrigin.{CSRD2, SEED}
 import uk.gov.hmrc.crdlcache.models.dps.codeList.CodeListEntry
 import uk.gov.hmrc.crdlcache.models.errors.ImportError.{
@@ -54,7 +54,7 @@ object CodeListSnapshotEntry {
     LocalDate.parse(value, dateFormat).atStartOfDay(ZoneOffset.UTC).toInstant
 
   def fromDpsEntry(
-    config: CodeListConfig,
+    config: ListConfig,
     dpsEntry: CodeListEntry
   ): CodeListSnapshotEntry = {
     val key = dpsEntry
@@ -62,10 +62,18 @@ object CodeListSnapshotEntry {
       .flatMap(_.dataitem_value)
       .getOrElse(throw RequiredDataItemMissing(config.keyProperty))
 
-    val value = dpsEntry.language
-      .find(_.lang_code.equalsIgnoreCase("en"))
-      .map(_.lang_desc)
-      .getOrElse(throw LanguageDescriptionMissing)
+    val value = config match {
+      case _: CodeListConfig =>
+        dpsEntry.language
+          .find(_.lang_code.equalsIgnoreCase("en"))
+          .map(_.lang_desc)
+          .getOrElse(throw LanguageDescriptionMissing)
+      case correspondence: CorrespondenceListConfig =>
+        dpsEntry
+          .getProperty(correspondence.valueProperty)
+          .flatMap(_.dataitem_value)
+          .getOrElse(throw RequiredDataItemMissing(correspondence.valueProperty))
+    }
 
     val activeFrom = dpsEntry
       .getProperty(config.origin.activeDateProperty)
@@ -83,7 +91,13 @@ object CodeListSnapshotEntry {
       .flatMap(_.dataitem_value)
       .map { value => Operation.fromString(value).getOrElse(throw UnknownOperation(value)) }
 
-    val usedProperties = knownProperties.incl(config.keyProperty)
+    val usedProperties =
+      config match {
+        case _: CodeListConfig =>
+          knownProperties.incl(config.keyProperty)
+        case correspondence: CorrespondenceListConfig =>
+          knownProperties.incl(config.keyProperty).incl(correspondence.valueProperty)
+      }
 
     val builder = Json.newBuilder
 

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListType.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListType.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.models
+
+enum CodeListType {
+  case STANDARD, CORRESPONDENCE
+}

--- a/app/uk/gov/hmrc/crdlcache/models/CorrespondenceListInstruction.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CorrespondenceListInstruction.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.models
+
+import java.time.Instant
+
+enum CorrespondenceListInstruction {
+  case UpsertEntry(codeListEntry: CodeListEntry)
+
+  case InvalidateEntry(codeListEntry: CodeListEntry)
+
+  // case DeleteEntry(codeListEntry: CodeListEntry)
+
+  case RecordMissingEntry(
+    codeListCode: CodeListCode,
+    override val key: String,
+    override val value: String,
+    removedAt: Instant
+  )
+
+  def key: String = this match {
+    case CorrespondenceListInstruction.UpsertEntry(codeListEntry)     => codeListEntry.key
+    case CorrespondenceListInstruction.InvalidateEntry(codeListEntry) => codeListEntry.key
+    // case CorrespondenceListInstruction.DeleteEntry(codeListEntry)     => codeListEntry.key
+    case CorrespondenceListInstruction.RecordMissingEntry(_, key, _, _) => key
+  }
+
+  def value: String = this match {
+    case CorrespondenceListInstruction.UpsertEntry(codeListEntry)     => codeListEntry.value
+    case CorrespondenceListInstruction.InvalidateEntry(codeListEntry) => codeListEntry.value
+    // case Instruction.DeleteEntry(codeListEntry)     => codeListEntry.key
+    case CorrespondenceListInstruction.RecordMissingEntry(_, _, value, _) => value
+  }
+
+  def activeFrom: Instant = this match {
+    case CorrespondenceListInstruction.UpsertEntry(codeListEntry)     => codeListEntry.activeFrom
+    case CorrespondenceListInstruction.InvalidateEntry(codeListEntry) => codeListEntry.activeFrom
+    // case CorrespondenceListInstruction.DeleteEntry(codeListEntry)     => codeListEntry.activeFrom
+    case CorrespondenceListInstruction.RecordMissingEntry(_, _, _, removedAt) => removedAt
+  }
+}

--- a/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
@@ -83,7 +83,11 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
     )
 
     val keyFilters = filterKeys
-      .map(ks => if ks.nonEmpty then List(in("key", ks.toSeq*)) else List.empty)
+      .map { ks =>
+        if ks.nonEmpty
+        then List(in("key", ks.toSeq*))
+        else List.empty
+      }
       .getOrElse(List.empty)
 
     val propertyFilters = filterProperties

--- a/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
@@ -17,60 +17,65 @@
 package uk.gov.hmrc.crdlcache.repositories
 
 import com.mongodb.client.model.ReplaceOptions
+import org.bson.codecs.Codec
 import org.mongodb.scala.*
 import org.mongodb.scala.bson.BsonNull
+import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.*
 import org.mongodb.scala.model.Filters.*
 import play.api.libs.json.*
 import uk.gov.hmrc.crdlcache.models
 import uk.gov.hmrc.crdlcache.models.errors.MongoError
-import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry, Instruction}
+import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry}
 import uk.gov.hmrc.mongo.MongoComponent
-import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.transaction.Transactions
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
-import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
-@Singleton
-class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
+abstract class CodeListsRepository[K, I](
+  val mongoComponent: MongoComponent,
+  collectionName: String,
+  indexes: Seq[IndexModel],
+  extraCodecs: Seq[Codec[?]]
+)(using
   ec: ExecutionContext
 ) extends PlayMongoRepository[CodeListEntry](
     mongoComponent,
-    collectionName = "codelists",
+    collectionName,
     domainFormat = CodeListEntry.mongoFormat,
-    extraCodecs =
-      Codecs.playFormatSumCodecs[JsValue](Format(Reads.JsValueReads, Writes.jsValueWrites)) ++
-        Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)),
-    indexes = Seq(
-      IndexModel(
-        Indexes.ascending("codeListCode", "key", "activeFrom"),
-        IndexOptions().unique(true)
-      ),
-      IndexModel(
-        Indexes.ascending("activeTo"),
-        IndexOptions().expireAfter(30, TimeUnit.DAYS)
-      )
-    )
+    extraCodecs = extraCodecs,
+    indexes = IndexModel(
+      Indexes.ascending("activeTo"),
+      IndexOptions().expireAfter(30, TimeUnit.DAYS)
+    ) +: indexes
   )
   with Transactions {
 
-  def fetchCodeListEntryKeys(session: ClientSession, code: CodeListCode): Future[Set[String]] =
+  def activationDate(instruction: I): Instant
+
+  def keyOfEntry(codeListEntry: CodeListEntry): K
+
+  def filtersForKey(key: K): Seq[Bson]
+
+  def executeInstruction(session: ClientSession, instruction: I): Future[Unit]
+
+  def executeInstructions(session: ClientSession, instructions: List[I]): Future[Unit] =
+    instructions.sortBy(activationDate).foldLeft(Future.unit) {
+      (previousInstruction, nextInstruction) =>
+        previousInstruction.flatMap(_ => executeInstruction(session, nextInstruction))
+    }
+
+  def fetchEntryKeys(session: ClientSession, code: CodeListCode): Future[Set[K]] =
     collection
-      .find(
-        session,
-        and(
-          equal("codeListCode", code.code),
-          equal("activeTo", null)
-        )
-      )
-      .map(_.key)
-      .toFuture
+      .find(session, and(equal("codeListCode", code.code), equal("activeTo", null)))
+      .map(keyOfEntry)
+      .toFuture()
       .map(_.toSet)
 
-  def fetchCodeListEntries(
+  def fetchEntries(
     code: CodeListCode,
     filterKeys: Option[Set[String]],
     filterProperties: Option[Map[String, JsValue]],
@@ -106,10 +111,10 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
       .toFuture()
   }
 
-  private def supersedePreviousEntries(
+  protected def supersedePreviousEntries(
     session: ClientSession,
     codeListCode: CodeListCode,
-    key: String,
+    key: K,
     activeFrom: Instant,
     includeActiveFrom: Boolean
   ): Future[Unit] = {
@@ -117,10 +122,13 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
       .updateMany(
         session,
         and(
-          equal("codeListCode", codeListCode.code),
-          if includeActiveFrom then lte("activeFrom", activeFrom) else lt("activeFrom", activeFrom),
-          equal("key", key),
-          or(equal("activeTo", null), exists("activeTo", false))
+          Seq(
+            equal("codeListCode", codeListCode.code),
+            if includeActiveFrom
+            then lte("activeFrom", activeFrom)
+            else lt("activeFrom", activeFrom),
+            or(equal("activeTo", null), exists("activeTo", false))
+          ) ++ filtersForKey(key)*
         ),
         Updates.set("activeTo", activeFrom)
       )
@@ -131,14 +139,15 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
       }
   }
 
-  private def upsertEntry(session: ClientSession, codeListEntry: CodeListEntry) =
+  protected def upsertEntry(session: ClientSession, codeListEntry: CodeListEntry): Future[Unit] =
     collection
       .replaceOne(
         session,
         and(
-          equal("codeListCode", codeListEntry.codeListCode.code),
-          equal("activeFrom", codeListEntry.activeFrom),
-          equal("key", codeListEntry.key)
+          Seq(
+            equal("codeListCode", codeListEntry.codeListCode.code),
+            equal("activeFrom", codeListEntry.activeFrom)
+          ) ++ filtersForKey(keyOfEntry(codeListEntry))*
         ),
         codeListEntry,
         new ReplaceOptions().upsert(true)
@@ -150,40 +159,4 @@ class CodeListsRepository @Inject() (val mongoComponent: MongoComponent)(using
         else if (result.getModifiedCount == 0 && result.getUpsertedId == BsonNull)
           throw MongoError.NoMatchingDocument
       }
-
-  def executeInstructions(session: ClientSession, instructions: List[Instruction]): Future[Unit] =
-    instructions.sortBy(_.activeFrom).foldLeft(Future.unit) {
-      (previousInstruction, nextInstruction) =>
-        previousInstruction.flatMap { _ =>
-          nextInstruction match {
-            case models.Instruction.UpsertEntry(codeListEntry) =>
-              for {
-                _ <- supersedePreviousEntries(
-                  session,
-                  codeListEntry.codeListCode,
-                  codeListEntry.key,
-                  codeListEntry.activeFrom,
-                  includeActiveFrom = false
-                )
-                _ <- upsertEntry(session, codeListEntry)
-              } yield ()
-            case models.Instruction.InvalidateEntry(codeListEntry) =>
-              supersedePreviousEntries(
-                session,
-                codeListEntry.codeListCode,
-                codeListEntry.key,
-                codeListEntry.activeFrom,
-                includeActiveFrom = true
-              )
-            case models.Instruction.RecordMissingEntry(codeListCode, key, removedAt) =>
-              supersedePreviousEntries(
-                session,
-                codeListCode,
-                key,
-                removedAt,
-                includeActiveFrom = true
-              )
-          }
-        }
-    }
 }

--- a/app/uk/gov/hmrc/crdlcache/repositories/CorrespondenceListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/CorrespondenceListsRepository.scala
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.repositories
+
+import com.mongodb.client.model.ReplaceOptions
+import org.mongodb.scala.*
+import org.mongodb.scala.bson.BsonNull
+import org.mongodb.scala.model.*
+import org.mongodb.scala.model.Filters.*
+import play.api.libs.json.*
+import uk.gov.hmrc.crdlcache.models
+import uk.gov.hmrc.crdlcache.models.errors.MongoError
+import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry, CorrespondenceListInstruction}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
+import uk.gov.hmrc.mongo.transaction.Transactions
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class CorrespondenceListsRepository @Inject() (val mongoComponent: MongoComponent)(using
+  ec: ExecutionContext
+) extends PlayMongoRepository[CodeListEntry](
+    mongoComponent,
+    collectionName = "correspondenceLists",
+    domainFormat = CodeListEntry.mongoFormat,
+    extraCodecs =
+      Codecs.playFormatSumCodecs[JsValue](Format(Reads.JsValueReads, Writes.jsValueWrites)) ++
+        Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)),
+    indexes = Seq(
+      IndexModel(
+        Indexes.ascending("codeListCode", "key", "value", "activeFrom"),
+        IndexOptions().unique(true)
+      ),
+      IndexModel(
+        Indexes.ascending("activeTo"),
+        IndexOptions().expireAfter(30, TimeUnit.DAYS)
+      )
+    )
+  )
+  with Transactions {
+
+  def fetchCorrespondenceKeys(
+    session: ClientSession,
+    code: CodeListCode
+  ): Future[Set[(String, String)]] =
+    collection
+      .find(
+        session,
+        and(
+          equal("codeListCode", code.code),
+          equal("activeTo", null)
+        )
+      )
+      .map(entry => (entry.key, entry.value))
+      .toFuture()
+      .map(_.toSet)
+
+  def fetchCorrespondenceListEntries(
+    code: CodeListCode,
+    filterKeys: Option[Set[String]],
+    activeAt: Instant
+  ): Future[Seq[CodeListEntry]] = {
+    val mandatoryFilters = List(
+      equal("codeListCode", code.code),
+      lte("activeFrom", activeAt),
+      or(equal("activeTo", null), gt("activeTo", activeAt))
+    )
+
+    val keyFilters = filterKeys
+      .map(ks => if ks.nonEmpty then List(in("key", ks.toSeq*)) else List.empty)
+      .getOrElse(List.empty)
+
+    val allFilters = mandatoryFilters ++ keyFilters
+
+    collection
+      .find(and(allFilters*))
+      .sort(Sorts.ascending("key"))
+      .toFuture()
+  }
+
+  private def deleteCorrespondenceListEntries(
+    session: ClientSession,
+    codeListCode: CodeListCode
+  ): Future[Unit] =
+    collection
+      .deleteMany(
+        session,
+        equal("codeListCode", codeListCode.code)
+      )
+      .toFuture()
+      .map { result =>
+        if (!result.wasAcknowledged())
+          throw MongoError.NotAcknowledged
+      }
+
+  def saveCorrespondenceListEntries(
+    session: ClientSession,
+    codeListCode: CodeListCode,
+    entries: List[CodeListEntry]
+  ): Future[Unit] =
+    for {
+      _ <- deleteCorrespondenceListEntries(session, codeListCode)
+
+      _ <- collection.insertMany(session, entries).toFuture().map { result =>
+        if (!result.wasAcknowledged())
+          throw MongoError.NotAcknowledged
+      }
+    } yield ()
+
+  private def supersedePreviousEntries(
+    session: ClientSession,
+    codeListCode: CodeListCode,
+    key: String,
+    value: String,
+    activeFrom: Instant,
+    includeActiveFrom: Boolean
+  ): Future[Unit] = {
+    collection
+      .updateMany(
+        session,
+        and(
+          equal("codeListCode", codeListCode.code),
+          if includeActiveFrom then lte("activeFrom", activeFrom) else lt("activeFrom", activeFrom),
+          equal("key", key),
+          equal("value", value),
+          or(equal("activeTo", null), exists("activeTo", false))
+        ),
+        Updates.set("activeTo", activeFrom)
+      )
+      .toFuture()
+      .map { result =>
+        if (!result.wasAcknowledged())
+          throw MongoError.NotAcknowledged
+      }
+  }
+
+  private def upsertEntry(session: ClientSession, codeListEntry: CodeListEntry) =
+    collection
+      .replaceOne(
+        session,
+        and(
+          equal("codeListCode", codeListEntry.codeListCode.code),
+          equal("activeFrom", codeListEntry.activeFrom),
+          equal("key", codeListEntry.key),
+          equal("value", codeListEntry.value)
+        ),
+        codeListEntry,
+        new ReplaceOptions().upsert(true)
+      )
+      .toFuture()
+      .map { result =>
+        if (!result.wasAcknowledged())
+          throw MongoError.NotAcknowledged
+        else if (result.getModifiedCount == 0 && result.getUpsertedId == BsonNull)
+          throw MongoError.NoMatchingDocument
+      }
+
+  def executeInstructions(
+    session: ClientSession,
+    instructions: List[CorrespondenceListInstruction]
+  ): Future[Unit] =
+    instructions.sortBy(_.activeFrom).foldLeft(Future.unit) {
+      (previousInstruction, nextInstruction) =>
+        previousInstruction.flatMap { _ =>
+          nextInstruction match {
+            case CorrespondenceListInstruction.UpsertEntry(codeListEntry) =>
+              for {
+                _ <- supersedePreviousEntries(
+                  session,
+                  codeListEntry.codeListCode,
+                  codeListEntry.key,
+                  codeListEntry.value,
+                  codeListEntry.activeFrom,
+                  includeActiveFrom = false
+                )
+                _ <- upsertEntry(session, codeListEntry)
+              } yield ()
+            case CorrespondenceListInstruction.InvalidateEntry(codeListEntry) =>
+              supersedePreviousEntries(
+                session,
+                codeListEntry.codeListCode,
+                codeListEntry.key,
+                codeListEntry.value,
+                codeListEntry.activeFrom,
+                includeActiveFrom = true
+              )
+            case CorrespondenceListInstruction.RecordMissingEntry(
+                  codeListCode,
+                  key,
+                  value,
+                  removedAt
+                ) =>
+              supersedePreviousEntries(
+                session,
+                codeListCode,
+                key,
+                value,
+                removedAt,
+                includeActiveFrom = true
+              )
+          }
+        }
+    }
+}

--- a/app/uk/gov/hmrc/crdlcache/repositories/StandardCodeListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/StandardCodeListsRepository.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.repositories
+
+import org.mongodb.scala.*
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.*
+import org.mongodb.scala.model.Filters.*
+import play.api.libs.json.*
+import uk.gov.hmrc.crdlcache.models
+import uk.gov.hmrc.crdlcache.models.Instruction.{InvalidateEntry, RecordMissingEntry, UpsertEntry}
+import uk.gov.hmrc.crdlcache.models.{CodeListEntry, Instruction}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.Codecs
+
+import java.time.Instant
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class StandardCodeListsRepository @Inject() (mongoComponent: MongoComponent)(using
+  ec: ExecutionContext
+) extends CodeListsRepository[String, Instruction](
+    mongoComponent,
+    collectionName = "codelists",
+    extraCodecs =
+      Codecs.playFormatSumCodecs[JsValue](Format(Reads.JsValueReads, Writes.jsValueWrites)) ++
+        Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)),
+    indexes = Seq(
+      IndexModel(
+        Indexes.ascending("codeListCode", "key", "activeFrom"),
+        IndexOptions().unique(true)
+      )
+    )
+  ) {
+
+  override def activationDate(instruction: Instruction): Instant = instruction.activeFrom
+
+  override def keyOfEntry(codeListEntry: CodeListEntry): String = codeListEntry.key
+
+  override def filtersForKey(key: String): Seq[Bson] = Seq(equal("key", key))
+
+  def executeInstruction(session: ClientSession, instruction: Instruction): Future[Unit] =
+    instruction match {
+      case UpsertEntry(codeListEntry) =>
+        for {
+          _ <- supersedePreviousEntries(
+            session,
+            codeListEntry.codeListCode,
+            codeListEntry.key,
+            codeListEntry.activeFrom,
+            includeActiveFrom = false
+          )
+          _ <- upsertEntry(session, codeListEntry)
+        } yield ()
+      case InvalidateEntry(codeListEntry) =>
+        supersedePreviousEntries(
+          session,
+          codeListEntry.codeListCode,
+          codeListEntry.key,
+          codeListEntry.activeFrom,
+          includeActiveFrom = true
+        )
+      case RecordMissingEntry(codeListCode, key, removedAt) =>
+        supersedePreviousEntries(
+          session,
+          codeListCode,
+          key,
+          removedAt,
+          includeActiveFrom = true
+        )
+    }
+}

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
@@ -22,26 +22,24 @@ import org.apache.pekko.stream.{ActorAttributes, DelayOverflowStrategy, Supervis
 import org.mongodb.scala.ClientSession
 import org.quartz.{Job, JobExecutionContext}
 import play.api.Logging
-import uk.gov.hmrc.crdlcache.config.{AppConfig, CodeListConfig}
+import uk.gov.hmrc.crdlcache.config.{AppConfig, ListConfig}
 import uk.gov.hmrc.crdlcache.connectors.DpsConnector
-import uk.gov.hmrc.crdlcache.models.*
-import uk.gov.hmrc.crdlcache.models.Instruction.{InvalidateEntry, RecordMissingEntry, UpsertEntry}
-import uk.gov.hmrc.crdlcache.models.Operation.{Create, Delete, Invalidate, Update}
+import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListSnapshot, CodeListSnapshotEntry}
 import uk.gov.hmrc.crdlcache.repositories.{CodeListsRepository, LastUpdatedRepository}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.lock.{LockService, MongoLockRepository}
 import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
 
-import java.time.{Clock, Instant, LocalDate, ZoneOffset}
-import javax.inject.Inject
+import java.time.{Clock, ZoneOffset}
 import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class ImportCodeListsJob @Inject() (
+abstract class ImportCodeListsJob[K, I](
+  val jobName: String,
   val mongoComponent: MongoComponent,
   val lockRepository: MongoLockRepository,
   lastUpdatedRepository: LastUpdatedRepository,
-  codeListsRepository: CodeListsRepository,
+  repository: CodeListsRepository[K, I],
   dpsConnector: DpsConnector,
   appConfig: AppConfig,
   clock: Clock
@@ -53,67 +51,33 @@ class ImportCodeListsJob @Inject() (
 
   given TransactionConfiguration = TransactionConfiguration.strict
 
-  val lockId: String = "import-code-lists"
-  val ttl: Duration  = 1.hour
+  override val lockId: String = jobName
+  override val ttl: Duration  = 1.hour
 
-  private def fetchCurrentEntries(
+  protected def listConfigs: List[ListConfig]
+
+  protected def keyOfEntry(codeListSnapshotEntry: CodeListSnapshotEntry): K
+
+  protected def processEntry(codeListCode: CodeListCode, newEntry: CodeListSnapshotEntry): I
+
+  protected def recordMissing(codeListCode: CodeListCode, key: K): I
+
+  def processSnapshot(
     session: ClientSession,
-    codeListCode: CodeListCode
-  ): Future[Set[String]] =
-    codeListsRepository.fetchCodeListEntryKeys(session, codeListCode)
-
-  private def executeInstructions(
-    session: ClientSession,
-    instructions: List[Instruction]
-  ): Future[Unit] =
-    codeListsRepository.executeInstructions(session, instructions)
-
-  private def setLastUpdated(
-    session: ClientSession,
-    codeListCode: CodeListCode,
-    snapshotVersion: Long,
-    lastUpdated: Instant
-  ) = lastUpdatedRepository.setLastUpdated(session, codeListCode, snapshotVersion, lastUpdated)
-
-  private[schedulers] def processEntry(
-    codeListCode: CodeListCode,
-    newEntry: CodeListSnapshotEntry
-  ): Instruction = {
-    val updatedEntry: CodeListEntry = CodeListEntry(
-      codeListCode,
-      newEntry.key,
-      newEntry.value,
-      newEntry.activeFrom,
-      None,
-      newEntry.updatedAt,
-      newEntry.properties
-    )
-
-    newEntry.operation match {
-      case Some(Create)     => UpsertEntry(updatedEntry)
-      case Some(Update)     => UpsertEntry(updatedEntry)
-      case Some(Invalidate) => InvalidateEntry(updatedEntry)
-      case Some(Delete)     => InvalidateEntry(updatedEntry)
-      case None             => UpsertEntry(updatedEntry)
-    }
-  }
-
-  private[schedulers] def processSnapshot(
-    session: ClientSession,
-    codeListConfig: CodeListConfig,
+    listConfig: ListConfig,
     newSnapshot: CodeListSnapshot
-  ): Future[List[Instruction]] = {
+  ): Future[List[I]] = {
     logger.info(
-      s"Importing ${codeListConfig.origin} codelist ${codeListConfig.code.code} (${newSnapshot.name}) version ${newSnapshot.version}"
+      s"Importing ${listConfig.origin} codelist ${listConfig.code.code} (${newSnapshot.name}) version ${newSnapshot.version}"
     )
 
-    fetchCurrentEntries(session, codeListConfig.code).map { currentKeySet =>
-      val incomingKeySet = newSnapshot.entries.map(_.key)
+    repository.fetchEntryKeys(session, listConfig.code).map { currentKeySet =>
+      val incomingKeySet = newSnapshot.entries.map(keyOfEntry)
       val mergedKeySet   = currentKeySet.union(incomingKeySet)
 
-      val groupedEntries = newSnapshot.entries.toList.groupBy(_.key)
+      val groupedEntries = newSnapshot.entries.toList.groupBy(keyOfEntry)
 
-      val instructions = List.newBuilder[Instruction]
+      val instructions = List.newBuilder[I]
 
       for (key <- mergedKeySet) {
         val hasExistingEntry = currentKeySet.contains(key)
@@ -140,14 +104,11 @@ class ImportCodeListsJob @Inject() (
         (hasExistingEntry, entriesByDate) match {
           case (_, Some(newEntries)) =>
             instructions ++= newEntries.map(
-              processEntry(codeListConfig.code, _)
+              processEntry(listConfig.code, _)
             )
 
           case (true, None) =>
-            // DPS provides no snapshot dates:
-            // the best we can do with removed entries is to use the start of today as their deactivation date
-            val startOfToday = LocalDate.now(clock).atStartOfDay(ZoneOffset.UTC)
-            instructions += RecordMissingEntry(codeListConfig.code, key, startOfToday.toInstant)
+            instructions += recordMissing(listConfig.code, key)
 
           case _ =>
             throw IllegalStateException(
@@ -160,7 +121,7 @@ class ImportCodeListsJob @Inject() (
     }
   }
 
-  private def importCodeList(codeListConfig: CodeListConfig): Future[Unit] = {
+  protected def importCodeList(codeListConfig: ListConfig): Future[Unit] = {
     for {
       // Fetch last updated timestamp
       storedLastUpdated <- lastUpdatedRepository.fetchLastUpdated(codeListConfig.code)
@@ -186,8 +147,13 @@ class ImportCodeListsJob @Inject() (
           withSessionAndTransaction { session =>
             for {
               instructions <- processSnapshot(session, codeListConfig, snapshot)
-              _            <- executeInstructions(session, instructions)
-              _ <- setLastUpdated(session, codeListConfig.code, snapshot.version, clock.instant())
+              _            <- repository.executeInstructions(session, instructions)
+              _ <- lastUpdatedRepository.setLastUpdated(
+                session,
+                codeListConfig.code,
+                snapshot.version,
+                clock.instant()
+              )
             } yield ()
           }
         }
@@ -206,15 +172,21 @@ class ImportCodeListsJob @Inject() (
   private[schedulers] def importCodeLists(): Future[Unit] = {
     val importCodeLists = Source(appConfig.codeListConfigs)
       .mapAsyncUnordered(Runtime.getRuntime.availableProcessors())(importCodeList)
-      .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
       .run()
       .map(_ => ())
 
-    importCodeLists.foreach(_ => logger.info("Importing codelists completed successfully"))
+    importCodeLists.foreach(_ => logger.info(s"${jobName} job completed successfully"))
 
     importCodeLists
   }
 
   def execute(context: JobExecutionContext): Unit =
-    Await.result(importCodeLists(), Duration.Inf)
+    Await.result(
+      withLock(importCodeLists()).map {
+        _.getOrElse {
+          logger.info(s"${jobName} job lock could not be obtained")
+        }
+      },
+      Duration.Inf
+    )
 }

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
@@ -206,6 +206,7 @@ class ImportCodeListsJob @Inject() (
   private[schedulers] def importCodeLists(): Future[Unit] = {
     val importCodeLists = Source(appConfig.codeListConfigs)
       .mapAsyncUnordered(Runtime.getRuntime.availableProcessors())(importCodeList)
+      .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
       .run()
       .map(_ => ())
 

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
@@ -172,6 +172,7 @@ abstract class ImportCodeListsJob[K, I](
   private[schedulers] def importCodeLists(): Future[Unit] = {
     val importCodeLists = Source(appConfig.codeListConfigs)
       .mapAsyncUnordered(Runtime.getRuntime.availableProcessors())(importCodeList)
+      .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
       .run()
       .map(_ => ())
 

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
@@ -170,7 +170,7 @@ abstract class ImportCodeListsJob[K, I](
   }
 
   private[schedulers] def importCodeLists(): Future[Unit] = {
-    val importCodeLists = Source(appConfig.codeListConfigs)
+    val importCodeLists = Source(listConfigs)
       .mapAsyncUnordered(Runtime.getRuntime.availableProcessors())(importCodeList)
       .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
       .run()

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJob.scala
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.schedulers
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.{ActorAttributes, DelayOverflowStrategy, Supervision}
+import org.mongodb.scala.ClientSession
+import org.quartz.{Job, JobExecutionContext}
+import play.api.Logging
+import play.api.libs.json.Json
+import uk.gov.hmrc.crdlcache.config.{AppConfig, CorrespondenceListConfig}
+import uk.gov.hmrc.crdlcache.connectors.DpsConnector
+import uk.gov.hmrc.crdlcache.models.*
+import uk.gov.hmrc.crdlcache.models.CodeListCode.E200
+import uk.gov.hmrc.crdlcache.models.CorrespondenceListInstruction.{
+  InvalidateEntry,
+  RecordMissingEntry,
+  UpsertEntry
+}
+import uk.gov.hmrc.crdlcache.models.Operation.{Create, Delete, Invalidate, Update}
+import uk.gov.hmrc.crdlcache.repositories.{CorrespondenceListsRepository, LastUpdatedRepository}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.lock.{LockService, MongoLockRepository}
+import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
+
+import java.time.{Clock, Instant, LocalDate, ZoneOffset}
+import javax.inject.Inject
+import scala.concurrent.duration.*
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+class ImportCorrespondenceListsJob @Inject() (
+  val mongoComponent: MongoComponent,
+  val lockRepository: MongoLockRepository,
+  lastUpdatedRepository: LastUpdatedRepository,
+  correspondenceListsRepository: CorrespondenceListsRepository,
+  dpsConnector: DpsConnector,
+  appConfig: AppConfig,
+  clock: Clock
+)(using system: ActorSystem, ec: ExecutionContext)
+  extends Job
+  with LockService
+  with Logging
+  with Transactions {
+
+  given TransactionConfiguration = TransactionConfiguration.strict
+
+  val lockId: String = "import-correspondence-lists"
+  val ttl: Duration  = 1.hour
+
+  private def fetchCurrentEntries(
+    session: ClientSession,
+    codeListCode: CodeListCode
+  ): Future[Set[(String, String)]] =
+    correspondenceListsRepository.fetchCorrespondenceKeys(session, codeListCode)
+
+  private def executeInstructions(
+    session: ClientSession,
+    instructions: List[CorrespondenceListInstruction]
+  ): Future[Unit] =
+    correspondenceListsRepository.executeInstructions(session, instructions)
+
+  private def setLastUpdated(
+    session: ClientSession,
+    codeListCode: CodeListCode,
+    snapshotVersion: Long,
+    lastUpdated: Instant
+  ) = lastUpdatedRepository.setLastUpdated(session, codeListCode, snapshotVersion, lastUpdated)
+
+  private[schedulers] def processEntry(
+    codeListCode: CodeListCode,
+    newEntry: CodeListSnapshotEntry
+  ): CorrespondenceListInstruction = {
+    val updatedEntry: CodeListEntry = CodeListEntry(
+      codeListCode,
+      newEntry.key,
+      newEntry.value,
+      newEntry.activeFrom,
+      None,
+      newEntry.updatedAt,
+      newEntry.properties
+    )
+
+    newEntry.operation match {
+      case Some(Create)     => UpsertEntry(updatedEntry)
+      case Some(Update)     => UpsertEntry(updatedEntry)
+      case Some(Invalidate) => InvalidateEntry(updatedEntry)
+      case Some(Delete)     => InvalidateEntry(updatedEntry)
+      case None             => UpsertEntry(updatedEntry)
+    }
+  }
+
+  private[schedulers] def processSnapshot(
+    session: ClientSession,
+    correspondenceListConfig: CorrespondenceListConfig,
+    newSnapshot: CodeListSnapshot
+  ): Future[List[CorrespondenceListInstruction]] = {
+    logger.info(
+      s"Importing ${correspondenceListConfig.origin} codelist ${correspondenceListConfig.code.code} (${newSnapshot.name}) version ${newSnapshot.version}"
+    )
+
+    fetchCurrentEntries(session, correspondenceListConfig.code).map { currentKeySet =>
+      val incomingKeySet = newSnapshot.entries.map(entry => (entry.key, entry.value))
+      val mergedKeySet   = currentKeySet.union(incomingKeySet)
+
+      val groupedEntries = newSnapshot.entries.toList.groupBy(entry => (entry.key, entry.value))
+
+      val instructions = List.newBuilder[CorrespondenceListInstruction]
+
+      for (mapping @ (key, value) <- mergedKeySet) {
+        val hasExistingEntry = currentKeySet.contains(mapping)
+        val maybeNewEntries  = groupedEntries.get(mapping)
+
+        // In case of multiple entries for a given key->value mapping with the same activation date,
+        // the one with the latest modification timestamp and latest action ID is used.
+        val entriesByDate = maybeNewEntries.map { newEntries =>
+          newEntries
+            .groupBy(_.activeFrom) // Group by activation date
+            .view
+            .mapValues(
+              _.maxBy(entry =>
+                (
+                  entry.updatedAt,
+                  entry.properties.value.get("actionIdentification").flatMap(_.asOpt[String])
+                )
+              )
+            ) // Pick the latest modification and SEED "ActionIdentification"
+            .values
+            .toSet
+        }
+
+        (hasExistingEntry, entriesByDate) match {
+          case (_, Some(newEntries)) =>
+            instructions ++= newEntries.map(
+              processEntry(correspondenceListConfig.code, _)
+            )
+
+          case (true, None) =>
+            // DPS provides no snapshot dates:
+            // the best we can do with removed entries is to use the start of today as their deactivation date
+            val startOfToday = LocalDate.now(clock).atStartOfDay(ZoneOffset.UTC)
+            instructions += RecordMissingEntry(
+              correspondenceListConfig.code,
+              key,
+              value,
+              startOfToday.toInstant
+            )
+
+          case _ =>
+            throw IllegalStateException(
+              "Impossible case - we have neither a new nor existing entry for a key->value mapping"
+            )
+        }
+      }
+
+      instructions.result()
+    }
+  }
+
+  private def importCorrespondenceList(
+    correspondenceListConfig: CorrespondenceListConfig
+  ): Future[Unit] = {
+    for {
+      // Fetch last updated timestamp
+      storedLastUpdated <- lastUpdatedRepository.fetchLastUpdated(correspondenceListConfig.code)
+      defaultLastUpdated = appConfig.defaultLastUpdated.atStartOfDay(ZoneOffset.UTC).toInstant
+      lastUpdated        = storedLastUpdated.map(_.lastUpdated).getOrElse(defaultLastUpdated)
+
+      _ = logger.info(
+        s"Importing correspondence list ${correspondenceListConfig.code.code} from DPS with last updated timestamp ${lastUpdated}"
+      )
+
+      _ <- dpsConnector
+        .fetchCodeListSnapshots(correspondenceListConfig.code, lastUpdated)
+        // Add a delay between calls to avoid overwhelming DPS
+        .delay(1.second, DelayOverflowStrategy.backpressure)
+        .mapConcat(_.elements)
+        .dropWhile { snapshot =>
+          // Ignore snapshot versions that we already have
+          storedLastUpdated.exists(_.snapshotVersion >= snapshot.snapshotversion)
+        }
+        .map(CodeListSnapshot.fromDpsSnapshot(correspondenceListConfig, _))
+        .mapAsync(1) { snapshot =>
+          // Ensure that we roll back if something goes wrong processing the snapshot
+          withSessionAndTransaction { session =>
+            for {
+              instructions <- processSnapshot(session, correspondenceListConfig, snapshot)
+              _            <- executeInstructions(session, instructions)
+              _ <- setLastUpdated(
+                session,
+                correspondenceListConfig.code,
+                snapshot.version,
+                clock.instant()
+              )
+            } yield ()
+          }
+        }
+        .withAttributes(ActorAttributes.withSupervisionStrategy { err =>
+          logger.error(
+            s"Stopping correspondence list ${correspondenceListConfig.code.code} import job due to exception",
+            err
+          )
+          Supervision.stop
+        })
+        .run()
+
+    } yield ()
+  }
+
+  private[schedulers] def importStaticData(): Future[Unit] = {
+    try {
+      val json    = Json.parse(getClass.getResourceAsStream("/data/E200.json"))
+      val entries = Json.fromJson[List[CodeListEntry]](json).get
+      withSessionAndTransaction { session =>
+        correspondenceListsRepository.saveCorrespondenceListEntries(session, E200, entries)
+      }
+    } catch {
+      case NonFatal(err) =>
+        logger.error("Error parsing static data for correspondence list E200", err)
+        Future.failed(err)
+    }
+  }
+
+  private[schedulers] def importCorrespondenceLists(): Future[Unit] = {
+    val importStaticLists = Source.future(importStaticData())
+
+    val importCorrespondenceLists = Source(appConfig.correspondenceListConfigs)
+      .mapAsyncUnordered(Runtime.getRuntime.availableProcessors())(importCorrespondenceList)
+
+    val importAll = importStaticLists.concat(importCorrespondenceLists).run().map(_ => ())
+
+    importAll.foreach(_ => logger.info("Importing correspondence lists completed successfully"))
+
+    importAll
+  }
+
+  def execute(context: JobExecutionContext): Unit =
+    Await.result(importCorrespondenceLists(), Duration.Inf)
+}

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJob.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.crdlcache.schedulers
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.{ActorAttributes, Supervision}
 import play.api.libs.json.Json
 import uk.gov.hmrc.crdlcache.config.{AppConfig, ListConfig}
 import uk.gov.hmrc.crdlcache.connectors.DpsConnector
@@ -133,6 +134,7 @@ class ImportCorrespondenceListsJob @Inject() (
 
     val importCorrespondenceLists = Source(appConfig.correspondenceListConfigs)
       .mapAsyncUnordered(Runtime.getRuntime.availableProcessors())(importCodeList)
+      .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
 
     val importAll = importStaticLists.concat(importCorrespondenceLists).run().map(_ => ())
 

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJob.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.schedulers
+
+import org.apache.pekko.actor.ActorSystem
+import uk.gov.hmrc.crdlcache.config.{AppConfig, ListConfig}
+import uk.gov.hmrc.crdlcache.connectors.DpsConnector
+import uk.gov.hmrc.crdlcache.models.*
+import uk.gov.hmrc.crdlcache.models.Instruction.{InvalidateEntry, RecordMissingEntry, UpsertEntry}
+import uk.gov.hmrc.crdlcache.models.Operation.{Create, Delete, Invalidate, Update}
+import uk.gov.hmrc.crdlcache.repositories.{LastUpdatedRepository, StandardCodeListsRepository}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.lock.MongoLockRepository
+
+import java.time.{Clock, LocalDate, ZoneOffset}
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class ImportStandardCodeListsJob @Inject() (
+  mongoComponent: MongoComponent,
+  lockRepository: MongoLockRepository,
+  lastUpdatedRepository: LastUpdatedRepository,
+  codeListsRepository: StandardCodeListsRepository,
+  dpsConnector: DpsConnector,
+  appConfig: AppConfig,
+  clock: Clock
+)(using system: ActorSystem, ec: ExecutionContext)
+  extends ImportCodeListsJob[String, Instruction](
+    "import-code-lists",
+    mongoComponent,
+    lockRepository,
+    lastUpdatedRepository,
+    codeListsRepository,
+    dpsConnector,
+    appConfig,
+    clock
+  ) {
+
+  override protected def listConfigs: List[ListConfig] =
+    appConfig.codeListConfigs
+
+  override protected def keyOfEntry(snapshotEntry: CodeListSnapshotEntry): String =
+    snapshotEntry.key
+
+  override protected def recordMissing(codeListCode: CodeListCode, key: String): Instruction = {
+    // DPS provides no snapshot dates:
+    // the best we can do with removed entries is to use the start of today as their deactivation date
+    val startOfToday = LocalDate.now(clock).atStartOfDay(ZoneOffset.UTC)
+    RecordMissingEntry(codeListCode, key, removedAt = startOfToday.toInstant)
+  }
+
+  override def processEntry(
+    codeListCode: CodeListCode,
+    newEntry: CodeListSnapshotEntry
+  ): Instruction = {
+    val updatedEntry: CodeListEntry = CodeListEntry(
+      codeListCode,
+      newEntry.key,
+      newEntry.value,
+      newEntry.activeFrom,
+      None,
+      newEntry.updatedAt,
+      newEntry.properties
+    )
+
+    newEntry.operation match {
+      case Some(Create)     => UpsertEntry(updatedEntry)
+      case Some(Update)     => UpsertEntry(updatedEntry)
+      case Some(Invalidate) => InvalidateEntry(updatedEntry)
+      case Some(Delete)     => InvalidateEntry(updatedEntry)
+      case None             => UpsertEntry(updatedEntry)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJob.scala
@@ -78,11 +78,9 @@ class ImportStandardCodeListsJob @Inject() (
     )
 
     newEntry.operation match {
-      case Some(Create)     => UpsertEntry(updatedEntry)
-      case Some(Update)     => UpsertEntry(updatedEntry)
-      case Some(Invalidate) => InvalidateEntry(updatedEntry)
-      case Some(Delete)     => InvalidateEntry(updatedEntry)
-      case None             => UpsertEntry(updatedEntry)
+      case Some(Create | Update)     => UpsertEntry(updatedEntry)
+      case Some(Invalidate | Delete) => InvalidateEntry(updatedEntry)
+      case None                      => UpsertEntry(updatedEntry)
     }
   }
 }

--- a/app/uk/gov/hmrc/crdlcache/schedulers/JobScheduler.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/JobScheduler.scala
@@ -38,7 +38,7 @@ class JobScheduler @Inject() (
   private val quartz: Scheduler = StdSchedulerFactory.getDefaultScheduler
 
   // Import code lists
-  private val codeListsJobDetail = newJob(classOf[ImportCodeListsJob])
+  private val codeListsJobDetail = newJob(classOf[ImportStandardCodeListsJob])
     .withIdentity("import-code-lists")
     .build()
 

--- a/app/uk/gov/hmrc/crdlcache/schedulers/JobScheduler.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/JobScheduler.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.crdlcache.schedulers
 import org.quartz.JobBuilder.newJob
 import org.quartz.TriggerBuilder.newTrigger
 import org.quartz.impl.StdSchedulerFactory
-import org.quartz.{CronScheduleBuilder, Scheduler, SchedulerFactory}
+import org.quartz.{CronScheduleBuilder, Scheduler, SchedulerFactory, Trigger}
 import play.api.Logging
 import play.api.inject.ApplicationLifecycle
 import uk.gov.hmrc.crdlcache.config.AppConfig
@@ -64,16 +64,23 @@ class JobScheduler @Inject() (
     .withSchedule(correspondenceListsJobSchedule)
     .build()
 
+  private def getJobStatus(trigger: Trigger): JobStatus =
+    JobStatus(quartz.getTriggerState(trigger.getKey))
+
   def startCodeListImport(): Unit = {
     quartz.triggerJob(codeListsJobDetail.getKey)
   }
 
   def codeListImportStatus(): JobStatus = {
-    JobStatus(quartz.getTriggerState(codeListsJobTrigger.getKey))
+    getJobStatus(codeListsJobTrigger)
   }
 
   def startCorrespondenceListImport(): Unit = {
     quartz.triggerJob(correspondenceListsJobDetail.getKey)
+  }
+
+  def correspondenceListImportStatus(): JobStatus = {
+    getJobStatus(correspondenceListsJobTrigger)
   }
 
   private def startScheduler(): Unit = {

--- a/app/uk/gov/hmrc/crdlcache/schedulers/JobScheduler.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/JobScheduler.scala
@@ -50,8 +50,25 @@ class JobScheduler @Inject() (
     .withSchedule(codeListsJobSchedule)
     .build()
 
+  // Import correspondence lists
+  private val correspondenceListsJobDetail = newJob(classOf[ImportCorrespondenceListsJob])
+    .withIdentity("import-correspondence-lists")
+    .build()
+
+  private val correspondenceListsJobSchedule = CronScheduleBuilder
+    .cronSchedule(config.importCorrespondenceListsSchedule)
+
+  private val correspondenceListsJobTrigger = newTrigger()
+    .forJob(correspondenceListsJobDetail)
+    .withSchedule(correspondenceListsJobSchedule)
+    .build()
+
   def startCodeListImport(): Unit = {
     quartz.triggerJob(codeListsJobDetail.getKey)
+  }
+
+  def startCorrespondenceListImport(): Unit = {
+    quartz.triggerJob(correspondenceListsJobDetail.getKey)
   }
 
   private def startScheduler(): Unit = {
@@ -62,6 +79,7 @@ class JobScheduler @Inject() (
     lifecycle.addStopHook(() => Future(quartz.shutdown()))
 
     quartz.scheduleJob(codeListsJobDetail, codeListsJobTrigger)
+    quartz.scheduleJob(correspondenceListsJobDetail, correspondenceListsJobTrigger)
 
     quartz.start()
   }

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val microservice = Project("crdl-cache", file("."))
     // suppress warnings in generated routes files
     scalacOptions ++= Seq(
       "-Wconf:src=routes/.*:s",
+      // Disable duplicate compiler option warning as it's caused by our sbt plugins
       "-Wconf:msg=Flag.*repeatedly:s",
       // Ignore test-only code
       "--coverage-exclude-classlikes:uk.gov.hmrc.crdlcache.controllers.testonly",
@@ -28,7 +29,8 @@ lazy val microservice = Project("crdl-cache", file("."))
       "uk.gov.hmrc.crdlcache.models.Binders.bindableJsValueMap",
       "uk.gov.hmrc.crdlcache.models.Binders.bindableSet"
     ),
-    Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
+    // Change classloader layering to avert classloading issues
+    Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
   )
 
 lazy val it = project
@@ -38,7 +40,10 @@ lazy val it = project
   .settings(DefaultBuildSettings.itSettings())
   .settings(
     libraryDependencies ++= AppDependencies.it,
-    Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
+    // Change classloader layering to avert classloading issues
+    Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
+    // Disable duplicate compiler option warning as it's caused by our sbt plugins
+    scalacOptions += "-Wconf:msg=Flag.*repeatedly:s"
   )
 
 addCommandAlias("runAllChecks", ";clean;compile;scalafmtAll;coverage;test;it/test;coverageReport")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,4 @@
 # microservice specific routes
 
-GET        /lists     uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListVersions
-GET        /lists/:code        uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListEntries(code: CodeListCode, keys: Option[Set[String]] ?= None, properties: Option[Map[String, JsValue]] ?= None, activeAt: Option[Instant])
+GET        /lists         uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListVersions
+GET        /lists/:code   uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListEntries(code: CodeListCode, keys: Option[Set[String]] ?= None, properties: Option[Map[String, JsValue]] ?= None, activeAt: Option[Instant])

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -63,12 +63,12 @@ mongodb {
   uri = "mongodb://localhost:27017/crdl-cache"
 }
 
+last-updated-date {
+  default = "2025-03-12"
+}
+
 import-codelists {
   schedule = "0 0 4 * * ?"
-
-  last-updated-date {
-    default = "2025-03-12"
-  }
 
   codelists = [
     {
@@ -211,6 +211,19 @@ import-codelists {
       origin = "SEED"
       keyProperty = "NationalAdministrationDegreePlatoCode"
     }
+  ]
+}
+
+import-correspondence-lists {
+  schedule = "0 0 4 * * ?"
+
+  correspondence-lists = [
+    # {
+    #   code = "E200"
+    #   origin = "SEED"
+    #   keyProperty = "CnCode"
+    #   valueProperty = "ExciseProductCode"
+    # }
   ]
 }
 

--- a/conf/data/E200.json
+++ b/conf/data/E200.json
@@ -1,0 +1,3642 @@
+[
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "351"},
+    "key": "22030001",
+    "value": "B000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "352"},
+    "key": "22030009",
+    "value": "B000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "353"},
+    "key": "22060089",
+    "value": "B000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "354"},
+    "key": "22060039",
+    "value": "B000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "355"},
+    "key": "22060059",
+    "value": "B000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "356"},
+    "key": "22030010",
+    "value": "B000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "357"},
+    "key": "15121110",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "358"},
+    "key": "15121910",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "359"},
+    "key": "15122110",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "360"},
+    "key": "15122910",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "361"},
+    "key": "15131110",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-07-11T00:00:00Z",
+    "updatedAt": "2020-07-10T10:17:40Z",
+    "properties": {"actionIdentification": "362"},
+    "key": "15180095",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "363"},
+    "key": "15092000",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "364"},
+    "key": "15093000",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "365"},
+    "key": "15094000",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "366"},
+    "key": "15101000",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "367"},
+    "key": "15109000",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "368"},
+    "key": "15156011",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "369"},
+    "key": "15156060",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "370"},
+    "key": "15163091",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "371"},
+    "key": "15131911",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "372"},
+    "key": "15131919",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "373"},
+    "key": "15131930",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "374"},
+    "key": "15132110",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "375"},
+    "key": "15132911",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "376"},
+    "key": "15132919",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "377"},
+    "key": "15132930",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "378"},
+    "key": "15141110",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "379"},
+    "key": "15141910",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "380"},
+    "key": "15149110",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "381"},
+    "key": "15149910",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "382"},
+    "key": "15151100",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "383"},
+    "key": "15151910",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "384"},
+    "key": "15152110",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "385"},
+    "key": "15152910",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "386"},
+    "key": "15153090",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "387"},
+    "key": "15155011",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "388"},
+    "key": "15155091",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "389"},
+    "key": "15159011",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "390"},
+    "key": "15159021",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "391"},
+    "key": "15159031",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "392"},
+    "key": "15159040",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "393"},
+    "key": "15159060",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "394"},
+    "key": "15161010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "395"},
+    "key": "15161090",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "396"},
+    "key": "15162010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "397"},
+    "key": "15162091",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "398"},
+    "key": "15162095",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "399"},
+    "key": "15171010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "400"},
+    "key": "15171090",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "401"},
+    "key": "15179010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "402"},
+    "key": "15179091",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "403"},
+    "key": "15179093",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "404"},
+    "key": "15179099",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "405"},
+    "key": "15180010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "406"},
+    "key": "15180031",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "407"},
+    "key": "15180039",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "408"},
+    "key": "15071010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "409"},
+    "key": "15079010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "410"},
+    "key": "15081010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "411"},
+    "key": "15089010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "412"},
+    "key": "15099000",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "413"},
+    "key": "15111010",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "414"},
+    "key": "15119011",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "415"},
+    "key": "15119019",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:16Z",
+    "properties": {"actionIdentification": "416"},
+    "key": "15119091",
+    "value": "E200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:11Z",
+    "properties": {"actionIdentification": "417"},
+    "key": "27071000",
+    "value": "E300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:12Z",
+    "properties": {"actionIdentification": "418"},
+    "key": "27072000",
+    "value": "E300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:12Z",
+    "properties": {"actionIdentification": "419"},
+    "key": "27073000",
+    "value": "E300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:12Z",
+    "properties": {"actionIdentification": "420"},
+    "key": "27075000",
+    "value": "E300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2019-01-01T00:00:00Z",
+    "updatedAt": "2018-12-19T18:57:36Z",
+    "properties": {"actionIdentification": "421"},
+    "key": "27101250",
+    "value": "E410"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "422"},
+    "key": "27101231",
+    "value": "E410"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "423"},
+    "key": "27101231",
+    "value": "E420"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "424"},
+    "key": "27101241",
+    "value": "E420"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "425"},
+    "key": "27101245",
+    "value": "E420"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "426"},
+    "key": "27101249",
+    "value": "E420"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "427"},
+    "key": "27101948",
+    "value": "E430"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "428"},
+    "key": "27102016",
+    "value": "E430"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "429"},
+    "key": "27101946",
+    "value": "E430"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "430"},
+    "key": "27102011",
+    "value": "E430"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "432"},
+    "key": "27102019",
+    "value": "E430"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "433"},
+    "key": "27101947",
+    "value": "E430"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2025-01-01T00:00:00Z",
+    "updatedAt": null,
+    "properties": {"actionIdentification": "2410"},
+    "key": "27101942",
+    "value": "E430"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2025-01-01T00:00:00Z",
+    "updatedAt": null,
+    "properties": {"actionIdentification": "2411"},
+    "key": "27101942",
+    "value": "E440"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2025-01-01T00:00:00Z",
+    "updatedAt": null,
+    "properties": {"actionIdentification": "2412"},
+    "key": "27101944",
+    "value": "E430"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2025-01-01T00:00:00Z",
+    "updatedAt": null,
+    "properties": {"actionIdentification": "2413"},
+    "key": "27101944",
+    "value": "E440"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "435"},
+    "key": "27102016",
+    "value": "E440"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "436"},
+    "key": "27102019",
+    "value": "E440"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "437"},
+    "key": "27102011",
+    "value": "E440"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "438"},
+    "key": "27101948",
+    "value": "E440"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "439"},
+    "key": "27101947",
+    "value": "E440"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "440"},
+    "key": "27101946",
+    "value": "E440"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "441"},
+    "key": "27101925",
+    "value": "E450"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "442"},
+    "key": "27101921",
+    "value": "E450"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "443"},
+    "key": "27101925",
+    "value": "E460"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "444"},
+    "key": "27102032",
+    "value": "E470"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "445"},
+    "key": "27102038",
+    "value": "E470"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "446"},
+    "key": "27101966",
+    "value": "E470"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "447"},
+    "key": "27101967",
+    "value": "E470"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "448"},
+    "key": "27101962",
+    "value": "E470"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "449"},
+    "key": "27101225",
+    "value": "E480"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "450"},
+    "key": "27101929",
+    "value": "E480"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "451"},
+    "key": "27101221",
+    "value": "E480"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2018-09-15T00:00:00Z",
+    "updatedAt": "2018-09-04T14:10:24Z",
+    "properties": {"actionIdentification": "452"},
+    "key": "27102090",
+    "value": "E480"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "453"},
+    "key": "27101211",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "454"},
+    "key": "27101215",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "455"},
+    "key": "27101270",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "456"},
+    "key": "27101290",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "457"},
+    "key": "27101911",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "458"},
+    "key": "27101915",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "459"},
+    "key": "27101931",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "460"},
+    "key": "27101935",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "461"},
+    "key": "27101951",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:21Z",
+    "properties": {"actionIdentification": "462"},
+    "key": "27101955",
+    "value": "E490"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "463"},
+    "key": "27111211",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "464"},
+    "key": "27111219",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "465"},
+    "key": "27111291",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "466"},
+    "key": "27111293",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "467"},
+    "key": "27111294",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "468"},
+    "key": "27111900",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "469"},
+    "key": "27111310",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "470"},
+    "key": "27111330",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "471"},
+    "key": "27111391",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "472"},
+    "key": "27111397",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "473"},
+    "key": "27111400",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "474"},
+    "key": "27111297",
+    "value": "E500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "475"},
+    "key": "29011000",
+    "value": "E600"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "476"},
+    "key": "29022000",
+    "value": "E700"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "477"},
+    "key": "29023000",
+    "value": "E700"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "478"},
+    "key": "29024400",
+    "value": "E700"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "479"},
+    "key": "29024200",
+    "value": "E700"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "480"},
+    "key": "29024300",
+    "value": "E700"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "481"},
+    "key": "29024100",
+    "value": "E700"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "482"},
+    "key": "29051100",
+    "value": "E800"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:22Z",
+    "properties": {"actionIdentification": "483"},
+    "key": "38260010",
+    "value": "E910"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "484"},
+    "key": "38249200",
+    "value": "E920"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "485"},
+    "key": "38249986",
+    "value": "E920"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "486"},
+    "key": "38249992",
+    "value": "E920"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "487"},
+    "key": "38249993",
+    "value": "E920"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "488"},
+    "key": "38249996",
+    "value": "E920"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2019-01-19T00:00:00Z",
+    "updatedAt": "2019-01-18T09:05:09Z",
+    "properties": {"actionIdentification": "489"},
+    "key": "38260090",
+    "value": "E920"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-01-01T00:00:00Z",
+    "updatedAt": "2021-12-21T15:04:29Z",
+    "properties": {"actionIdentification": "490"},
+    "key": "38248900",
+    "value": "E920"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:12Z",
+    "properties": {"actionIdentification": "491"},
+    "key": "38111900",
+    "value": "E930"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:12Z",
+    "properties": {"actionIdentification": "492"},
+    "key": "38111190",
+    "value": "E930"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:12Z",
+    "properties": {"actionIdentification": "493"},
+    "key": "38111110",
+    "value": "E930"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:12Z",
+    "properties": {"actionIdentification": "494"},
+    "key": "38119000",
+    "value": "E930"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "495"},
+    "key": "22042185",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "496"},
+    "key": "22042187",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "497"},
+    "key": "22042188",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "498"},
+    "key": "22042189",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "499"},
+    "key": "22042190",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "500"},
+    "key": "22042191",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "501"},
+    "key": "22042193",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "502"},
+    "key": "22042194",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "503"},
+    "key": "22042195",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "504"},
+    "key": "22042196",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "505"},
+    "key": "22042197",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "506"},
+    "key": "22042198",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "507"},
+    "key": "22042985",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "508"},
+    "key": "22042986",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "509"},
+    "key": "22042988",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "510"},
+    "key": "22042990",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "511"},
+    "key": "22042991",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "512"},
+    "key": "22042993",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "513"},
+    "key": "22042994",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "514"},
+    "key": "22042995",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "515"},
+    "key": "22042996",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "516"},
+    "key": "22042997",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "517"},
+    "key": "22042998",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "518"},
+    "key": "22051010",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "519"},
+    "key": "22051090",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "520"},
+    "key": "22059010",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "521"},
+    "key": "22059090",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "522"},
+    "key": "22060010",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "523"},
+    "key": "22060031",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "524"},
+    "key": "22060039",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "525"},
+    "key": "22060051",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "526"},
+    "key": "22060059",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "527"},
+    "key": "22060081",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "528"},
+    "key": "22060089",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2016-10-15T00:00:00Z",
+    "updatedAt": "2016-10-14T07:41:45Z",
+    "properties": {"actionIdentification": "529"},
+    "key": "22042138",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-03-17T00:00:00Z",
+    "updatedAt": "2020-03-16T16:33:18Z",
+    "properties": {"actionIdentification": "530"},
+    "key": "22042181",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "531"},
+    "key": "22042285",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "532"},
+    "key": "22042286",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "533"},
+    "key": "22042288",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "534"},
+    "key": "22042290",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "535"},
+    "key": "22042291",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "536"},
+    "key": "22042293",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "537"},
+    "key": "22042294",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "538"},
+    "key": "22042295",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "539"},
+    "key": "22042296",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "540"},
+    "key": "22042297",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "541"},
+    "key": "22042298",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "542"},
+    "key": "22042186",
+    "value": "I000"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "543"},
+    "key": "22042193",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "544"},
+    "key": "22042194",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "545"},
+    "key": "22042195",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "546"},
+    "key": "22042196",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "547"},
+    "key": "22042197",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "548"},
+    "key": "22042198",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "549"},
+    "key": "22042993",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "550"},
+    "key": "22042994",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "551"},
+    "key": "22042995",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "552"},
+    "key": "22042996",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "553"},
+    "key": "22042997",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "554"},
+    "key": "22042998",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "555"},
+    "key": "22051090",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "556"},
+    "key": "22059090",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "557"},
+    "key": "22060010",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "558"},
+    "key": "22060031",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "559"},
+    "key": "22060039",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "560"},
+    "key": "22060051",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "561"},
+    "key": "22060059",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "562"},
+    "key": "22060081",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "563"},
+    "key": "22060089",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "564"},
+    "key": "22082012",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "565"},
+    "key": "22082014",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "566"},
+    "key": "22082026",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "567"},
+    "key": "22082062",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "568"},
+    "key": "22082086",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "569"},
+    "key": "22083011",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "570"},
+    "key": "22083019",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "571"},
+    "key": "22083030",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "572"},
+    "key": "22083041",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "573"},
+    "key": "22083049",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "574"},
+    "key": "22083061",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "575"},
+    "key": "22083069",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "576"},
+    "key": "22083071",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "577"},
+    "key": "22083079",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "578"},
+    "key": "22083082",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "579"},
+    "key": "22083088",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "580"},
+    "key": "22084011",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "581"},
+    "key": "22084031",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "582"},
+    "key": "22084039",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "583"},
+    "key": "22084051",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "584"},
+    "key": "22084091",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "585"},
+    "key": "22084099",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "586"},
+    "key": "22085011",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "587"},
+    "key": "22085019",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "588"},
+    "key": "22085091",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "589"},
+    "key": "22085099",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "590"},
+    "key": "22086011",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "591"},
+    "key": "22086019",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "592"},
+    "key": "22086091",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "593"},
+    "key": "22086099",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "594"},
+    "key": "22087010",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "595"},
+    "key": "22087090",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "596"},
+    "key": "22089011",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "597"},
+    "key": "22089019",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "598"},
+    "key": "22089033",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "599"},
+    "key": "22089038",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "600"},
+    "key": "22089041",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "601"},
+    "key": "22089045",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "602"},
+    "key": "22089048",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "603"},
+    "key": "22089054",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "604"},
+    "key": "22089056",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "605"},
+    "key": "22089069",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "606"},
+    "key": "22089071",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "607"},
+    "key": "22089075",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "608"},
+    "key": "22089077",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "609"},
+    "key": "22089078",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "610"},
+    "key": "22042185",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "611"},
+    "key": "22042186",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "612"},
+    "key": "22042187",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "613"},
+    "key": "22042188",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "614"},
+    "key": "22042189",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "615"},
+    "key": "22042190",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "616"},
+    "key": "22042191",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "617"},
+    "key": "22042285",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "618"},
+    "key": "22042286",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "619"},
+    "key": "22042288",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "620"},
+    "key": "22042290",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "621"},
+    "key": "22042291",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "622"},
+    "key": "22042293",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "623"},
+    "key": "22042294",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "624"},
+    "key": "22042295",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "625"},
+    "key": "22042296",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "626"},
+    "key": "22042297",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "627"},
+    "key": "22042298",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "628"},
+    "key": "22042985",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "629"},
+    "key": "22042986",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "630"},
+    "key": "22042988",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "631"},
+    "key": "22042990",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "632"},
+    "key": "22042991",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:04Z",
+    "properties": {"actionIdentification": "633"},
+    "key": "22082016",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "634"},
+    "key": "22082018",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "635"},
+    "key": "22082019",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "636"},
+    "key": "22082028",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "637"},
+    "key": "22082066",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "638"},
+    "key": "22082069",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-01-01T00:00:00Z",
+    "updatedAt": "2019-12-20T15:50:05Z",
+    "properties": {"actionIdentification": "639"},
+    "key": "22082088",
+    "value": "S200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "640"},
+    "key": "22071000",
+    "value": "S300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "641"},
+    "key": "22089091",
+    "value": "S300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "642"},
+    "key": "22089099",
+    "value": "S300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "643"},
+    "key": "22072000",
+    "value": "S400"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2023-02-13T00:00:00Z",
+    "updatedAt": "2022-03-16T16:03:52Z",
+    "properties": {"actionIdentification": "644"},
+    "key": "22072000",
+    "value": "S600"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "645"},
+    "key": "24022010",
+    "value": "T200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "646"},
+    "key": "24022090",
+    "value": "T200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "647"},
+    "key": "24029000",
+    "value": "T200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "648"},
+    "key": "24021000",
+    "value": "T300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "649"},
+    "key": "24029000",
+    "value": "T400"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "650"},
+    "key": "24031910",
+    "value": "T400"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2020-12-18T00:00:00Z",
+    "updatedAt": "2020-12-17T21:21:04Z",
+    "properties": {"actionIdentification": "651"},
+    "key": "24039990",
+    "value": "T400"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "652"},
+    "key": "24039100",
+    "value": "T400"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "653"},
+    "key": "24031990",
+    "value": "T400"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "654"},
+    "key": "24039990",
+    "value": "T500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "655"},
+    "key": "24031990",
+    "value": "T500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "656"},
+    "key": "24031910",
+    "value": "T500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2022-05-15T00:00:00Z",
+    "updatedAt": "2022-05-13T12:35:45Z",
+    "properties": {"actionIdentification": "657"},
+    "key": "24041100",
+    "value": "T500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "658"},
+    "key": "24029000",
+    "value": "T500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:20Z",
+    "properties": {"actionIdentification": "659"},
+    "key": "24039100",
+    "value": "T500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-09-08T00:00:00Z",
+    "updatedAt": "2012-09-07T08:48:23Z",
+    "properties": {"actionIdentification": "660"},
+    "key": "24031100",
+    "value": "T500"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "661"},
+    "key": "22042278",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "662"},
+    "key": "22042279",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "663"},
+    "key": "22042280",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "664"},
+    "key": "22042281",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "665"},
+    "key": "22042282",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "666"},
+    "key": "22042283",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "667"},
+    "key": "22042284",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "668"},
+    "key": "22042285",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "669"},
+    "key": "22042286",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "670"},
+    "key": "22042288",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "671"},
+    "key": "22042290",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "672"},
+    "key": "22042291",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "673"},
+    "key": "22042293",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "674"},
+    "key": "22042294",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "675"},
+    "key": "22042295",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "676"},
+    "key": "22042296",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "677"},
+    "key": "22042297",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "678"},
+    "key": "22042298",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "679"},
+    "key": "22042922",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "680"},
+    "key": "22042923",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "681"},
+    "key": "22042924",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "682"},
+    "key": "22042926",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "683"},
+    "key": "22042927",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "684"},
+    "key": "22042928",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "685"},
+    "key": "22042932",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "686"},
+    "key": "22042938",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:58Z",
+    "properties": {"actionIdentification": "687"},
+    "key": "22042978",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "688"},
+    "key": "22042980",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "689"},
+    "key": "22042981",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "690"},
+    "key": "22042982",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "691"},
+    "key": "22042983",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "692"},
+    "key": "22042984",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "693"},
+    "key": "22042985",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "694"},
+    "key": "22042986",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "695"},
+    "key": "22042988",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "696"},
+    "key": "22042990",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "697"},
+    "key": "22042991",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "698"},
+    "key": "22042993",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "699"},
+    "key": "22042994",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "700"},
+    "key": "22042995",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "701"},
+    "key": "22042996",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "702"},
+    "key": "22042997",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "703"},
+    "key": "22042998",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "704"},
+    "key": "22043010",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "705"},
+    "key": "22043096",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "706"},
+    "key": "22043098",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "707"},
+    "key": "22051010",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "708"},
+    "key": "22059010",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "709"},
+    "key": "22060010",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "710"},
+    "key": "22060051",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "711"},
+    "key": "22060059",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "712"},
+    "key": "22060081",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "713"},
+    "key": "22060089",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-31T13:54:46Z",
+    "properties": {"actionIdentification": "714"},
+    "key": "22042107",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-31T13:54:46Z",
+    "properties": {"actionIdentification": "715"},
+    "key": "22042108",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-31T13:54:46Z",
+    "properties": {"actionIdentification": "716"},
+    "key": "22042109",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-01-01T00:00:00Z",
+    "updatedAt": "2012-12-10T14:15:11Z",
+    "properties": {"actionIdentification": "717"},
+    "key": "22042106",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2013-07-01T00:00:00Z",
+    "updatedAt": "2013-06-21T17:20:28Z",
+    "properties": {"actionIdentification": "718"},
+    "key": "22060031",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2014-07-01T00:00:00Z",
+    "updatedAt": "2014-06-30T07:05:57Z",
+    "properties": {"actionIdentification": "719"},
+    "key": "22060039",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2016-10-15T00:00:00Z",
+    "updatedAt": "2016-10-14T07:41:46Z",
+    "properties": {"actionIdentification": "720"},
+    "key": "22042910",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "721"},
+    "key": "22042131",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "722"},
+    "key": "22042161",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "723"},
+    "key": "22042210",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "724"},
+    "key": "22042222",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "725"},
+    "key": "22042223",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "726"},
+    "key": "22042224",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "727"},
+    "key": "22042226",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "728"},
+    "key": "22042227",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "729"},
+    "key": "22042228",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "730"},
+    "key": "22042232",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "731"},
+    "key": "22042233",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "732"},
+    "key": "22042238",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "733"},
+    "key": "22042111",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "734"},
+    "key": "22042112",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "735"},
+    "key": "22042113",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "736"},
+    "key": "22042117",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "737"},
+    "key": "22042118",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "738"},
+    "key": "22042119",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "739"},
+    "key": "22042122",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "740"},
+    "key": "22042123",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "741"},
+    "key": "22042124",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "742"},
+    "key": "22042126",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "743"},
+    "key": "22042127",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "744"},
+    "key": "22042128",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "745"},
+    "key": "22042132",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "746"},
+    "key": "22042134",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "747"},
+    "key": "22042136",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "748"},
+    "key": "22042137",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "749"},
+    "key": "22042138",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "750"},
+    "key": "22042142",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "751"},
+    "key": "22042143",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "752"},
+    "key": "22042144",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "753"},
+    "key": "22042146",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "754"},
+    "key": "22042147",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "755"},
+    "key": "22042148",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "756"},
+    "key": "22042162",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "757"},
+    "key": "22042166",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "758"},
+    "key": "22042167",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "759"},
+    "key": "22042168",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "760"},
+    "key": "22042169",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "761"},
+    "key": "22042171",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "762"},
+    "key": "22042174",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "763"},
+    "key": "22042176",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "764"},
+    "key": "22042177",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "765"},
+    "key": "22042178",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "766"},
+    "key": "22042179",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "767"},
+    "key": "22042180",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "768"},
+    "key": "22042181",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "769"},
+    "key": "22042182",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "770"},
+    "key": "22042183",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "771"},
+    "key": "22042184",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "772"},
+    "key": "22042185",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "773"},
+    "key": "22042186",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "774"},
+    "key": "22042187",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "775"},
+    "key": "22042188",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "776"},
+    "key": "22042189",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "777"},
+    "key": "22042190",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "778"},
+    "key": "22042191",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "779"},
+    "key": "22042193",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "780"},
+    "key": "22042194",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "781"},
+    "key": "22042195",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "782"},
+    "key": "22042196",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "783"},
+    "key": "22042197",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "784"},
+    "key": "22042198",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "785"},
+    "key": "22042979",
+    "value": "W200"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "786"},
+    "key": "22051010",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:18Z",
+    "properties": {"actionIdentification": "787"},
+    "key": "22042910",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "788"},
+    "key": "22060031",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "789"},
+    "key": "22060039",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "790"},
+    "key": "22041013",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "791"},
+    "key": "22041015",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2017-01-10T00:00:00Z",
+    "updatedAt": "2017-01-09T12:30:57Z",
+    "properties": {"actionIdentification": "792"},
+    "key": "22042210",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "793"},
+    "key": "22041011",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "794"},
+    "key": "22041091",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "795"},
+    "key": "22041093",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "796"},
+    "key": "22041094",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "797"},
+    "key": "22041096",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "798"},
+    "key": "22041098",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "799"},
+    "key": "22042106",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "800"},
+    "key": "22042107",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "801"},
+    "key": "22042108",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:17Z",
+    "properties": {"actionIdentification": "802"},
+    "key": "22042109",
+    "value": "W300"
+  },
+  {
+    "codeListCode": "E200",
+    "activeFrom": "2012-01-01T00:00:00Z",
+    "updatedAt": "2011-12-31T11:35:19Z",
+    "properties": {"actionIdentification": "803"},
+    "key": "22059010",
+    "value": "W300"
+  }
+]

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -16,6 +16,7 @@
 GET           /crdl-cache/test-only/codelists             uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.codeListImportStatus()
 POST          /crdl-cache/test-only/codelists             uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.importCodeLists()
 DELETE        /crdl-cache/test-only/codelists             uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteCodeLists()
+GET           /crdl-cache/test-only/correspondence-lists  uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.correspondenceListImportStatus()
 POST          /crdl-cache/test-only/correspondence-lists  uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.importCorrespondenceLists()
 DELETE        /crdl-cache/test-only/correspondence-lists  uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteCorrespondenceLists()
 DELETE        /crdl-cache/test-only/last-updated          uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteLastUpdated()

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -13,6 +13,8 @@
 ->            /                                         prod.Routes
 ->            /                                         definition.Routes
 
-POST          /crdl-cache/test-only/codelists           uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.importCodeLists()
-DELETE        /crdl-cache/test-only/codelists           uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteCodeLists()
-DELETE        /crdl-cache/test-only/last-updated        uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteLastUpdated()
+POST          /crdl-cache/test-only/codelists             uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.importCodeLists()
+DELETE        /crdl-cache/test-only/codelists             uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteCodeLists()
+POST          /crdl-cache/test-only/correspondence-lists  uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.importCorrespondenceLists()
+DELETE        /crdl-cache/test-only/correspondence-lists  uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteCorrespondenceLists()
+DELETE        /crdl-cache/test-only/last-updated          uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteLastUpdated()

--- a/it/test/uk/gov/hmrc/crdlcache/connectors/DpsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/connectors/DpsConnectorSpec.scala
@@ -29,24 +29,9 @@ import play.api.http.{HeaderNames, MimeTypes}
 import uk.gov.hmrc.crdlcache.config.AppConfig
 import uk.gov.hmrc.crdlcache.models.CodeListCode.BC08
 import uk.gov.hmrc.crdlcache.models.dps.*
-import RelationType.{Next, Prev, Self}
-import uk.gov.hmrc.crdlcache.models.dps.codeList.{
-  CodeListEntry,
-  CodeListResponse,
-  CodeListSnapshot,
-  DataItem,
-  LanguageDescription
-}
-import uk.gov.hmrc.crdlcache.models.dps.col.{
-  CustomsOfficeDetail,
-  CustomsOffice,
-  CustomsOfficeListResponse,
-  CustomsOfficeTimetable,
-  RDEntryStatus,
-  RoleTrafficCompetence,
-  SpecificNotes,
-  TimetableLine
-}
+import uk.gov.hmrc.crdlcache.models.dps.RelationType.{Next, Prev, Self}
+import uk.gov.hmrc.crdlcache.models.dps.codeList.*
+import uk.gov.hmrc.crdlcache.models.dps.col.*
 import uk.gov.hmrc.http.test.{HttpClientV2Support, WireMockSupport}
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 
@@ -83,10 +68,12 @@ class DpsConnectorSpec
       "microservice.services.dps-api.port"                 -> wireMockPort,
       "microservice.services.dps-api.clientId"             -> clientId,
       "microservice.services.dps-api.clientSecret"         -> clientSecret,
+      "last-updated-date.default"                          -> "2025-05-29",
       "import-codelists.schedule"                          -> "* * * * * ?",
       "import-offices.schedule"                            -> "* * * * * ?",
-      "import-codelists.last-updated-date.default"         -> "2025-05-29",
+      "import-correspondence-lists.schedule"               -> "* * * * * ?",
       "import-codelists.codelists"                         -> List.empty,
+      "import-correspondence-lists.correspondence-lists"   -> List.empty,
       "http-verbs.retries.intervals"                       -> List("1.millis")
     )
   )
@@ -874,8 +861,7 @@ class DpsConnectorSpec
     )
 
     recoverToSucceededIf[UpstreamErrorResponse] {
-      connector.
-        fetchCustomsOfficeLists
+      connector.fetchCustomsOfficeLists
         .runWith(Sink.collection[CustomsOfficeListResponse, List[CustomsOfficeListResponse]])
     }
   }
@@ -893,8 +879,7 @@ class DpsConnectorSpec
     )
 
     recoverToSucceededIf[UpstreamErrorResponse] {
-      connector
-        .fetchCustomsOfficeLists
+      connector.fetchCustomsOfficeLists
         .runWith(Sink.collection[CustomsOfficeListResponse, List[CustomsOfficeListResponse]])
     }
   }
@@ -925,8 +910,7 @@ class DpsConnectorSpec
     )
 
     recoverToSucceededIf[UpstreamErrorResponse] {
-      connector
-        .fetchCustomsOfficeLists
+      connector.fetchCustomsOfficeLists
         .runWith(Sink.collection[CustomsOfficeListResponse, List[CustomsOfficeListResponse]])
     }
   }
@@ -959,15 +943,14 @@ class DpsConnectorSpec
     )
 
     recoverToSucceededIf[UpstreamErrorResponse] {
-      connector
-        .fetchCustomsOfficeLists
+      connector.fetchCustomsOfficeLists
         .runWith(Sink.collection[CustomsOfficeListResponse, List[CustomsOfficeListResponse]])
     }
   }
 
   it should "not retry when there is a client error while fetching a page" in {
     val retryScenario = "Retry"
-    val failedState = "Failed"
+    val failedState   = "Failed"
 
     // Page 1 (Bad Request)
     stubFor(
@@ -1001,15 +984,14 @@ class DpsConnectorSpec
     )
 
     recoverToSucceededIf[UpstreamErrorResponse] {
-      connector
-        .fetchCustomsOfficeLists
+      connector.fetchCustomsOfficeLists
         .runWith(Sink.collection[CustomsOfficeListResponse, List[CustomsOfficeListResponse]])
     }
   }
 
   it should "retry when there is a server error while fetching a page" in {
-    val retryScenario   = "Retry"
-    val failedState     = "Failed"
+    val retryScenario = "Retry"
+    val failedState   = "Failed"
 
     // Page 1 (Internal Server Error)
     stubFor(
@@ -1070,8 +1052,7 @@ class DpsConnectorSpec
         )
     )
 
-    connector
-      .fetchCustomsOfficeLists
+    connector.fetchCustomsOfficeLists
       .runWith(Sink.collection[CustomsOfficeListResponse, List[CustomsOfficeListResponse]])
       .map(_ mustBe List(customsOfficeListPage1, customsOfficeListPage2))
   }

--- a/it/test/uk/gov/hmrc/crdlcache/controllers/CodeListsControllerSpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/controllers/CodeListsControllerSpec.scala
@@ -32,9 +32,9 @@ import play.api.libs.json.*
 import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, BC36, BC66, E200}
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry, LastUpdated}
 import uk.gov.hmrc.crdlcache.repositories.{
-  CodeListsRepository,
   CorrespondenceListsRepository,
-  LastUpdatedRepository
+  LastUpdatedRepository,
+  StandardCodeListsRepository
 }
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -57,7 +57,7 @@ class CodeListsControllerSpec
   given ExecutionContext = ExecutionContext.global
   given HeaderCarrier    = HeaderCarrier()
 
-  private val codeListsRepository           = mock[CodeListsRepository]
+  private val codeListsRepository           = mock[StandardCodeListsRepository]
   private val correspondenceListsRepository = mock[CorrespondenceListsRepository]
   private val lastUpdatedRepository         = mock[LastUpdatedRepository]
 
@@ -126,7 +126,7 @@ class CodeListsControllerSpec
   override def fakeApplication(): Application =
     GuiceApplicationBuilder()
       .overrides(
-        bind[CodeListsRepository].toInstance(codeListsRepository),
+        bind[StandardCodeListsRepository].toInstance(codeListsRepository),
         bind[CorrespondenceListsRepository].toInstance(correspondenceListsRepository),
         bind[LastUpdatedRepository].toInstance(lastUpdatedRepository),
         bind[HttpClientV2].toInstance(httpClientV2),
@@ -136,7 +136,7 @@ class CodeListsControllerSpec
 
   "CodeListsController" should "return 200 OK when there are no errors" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC08),
         equalTo(None),
         equalTo(None),
@@ -169,7 +169,7 @@ class CodeListsControllerSpec
 
   it should "use the correct repository for correspondence lists like E200" in {
     when(
-      correspondenceListsRepository.fetchCorrespondenceListEntries(
+      correspondenceListsRepository.fetchEntries(
         equalTo(E200),
         equalTo(None),
         equalTo(None),
@@ -202,7 +202,7 @@ class CodeListsControllerSpec
 
   it should "return 200 OK when there are no entries to return" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC08),
         equalTo(None),
         equalTo(None),
@@ -223,7 +223,7 @@ class CodeListsControllerSpec
 
   it should "parse comma-separated keys from the keys parameter when there is only one key" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC08),
         equalTo(Some(Set("GB"))),
         equalTo(None),
@@ -243,7 +243,7 @@ class CodeListsControllerSpec
 
   it should "parse comma-separated keys from the keys parameter when there are multiple keys" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC08),
         equalTo(Some(Set("GB", "XI"))),
         equalTo(None),
@@ -263,7 +263,7 @@ class CodeListsControllerSpec
 
   it should "parse comma-separated keys when there are multiple declarations of the keys parameter" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC08),
         equalTo(Some(Set("GB", "XI", "AW", "BL"))),
         equalTo(None),
@@ -283,7 +283,7 @@ class CodeListsControllerSpec
 
   it should "parse comma-separated keys when there is no value declared for the keys parameter" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC08),
         equalTo(Some(Set.empty)),
         equalTo(None),
@@ -303,7 +303,7 @@ class CodeListsControllerSpec
 
   it should "parse other query parameters as boolean property filters when they are valid boolean values" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC36),
         equalTo(Some(Set("B000"))),
         equalTo(Some(Map("alcoholicStrengthApplicabilityFlag" -> JsBoolean(true)))),
@@ -325,7 +325,7 @@ class CodeListsControllerSpec
 
   it should "parse other query parameters as null property filters when the query parameter value is null" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC66),
         equalTo(Some(Set("B"))),
         equalTo(Some(Map("responsibleDataManager" -> JsNull))),
@@ -347,7 +347,7 @@ class CodeListsControllerSpec
 
   it should "parse other query parameters as String property filters when they are neither boolean nor null values" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC08),
         equalTo(Some(Set("GB"))),
         equalTo(Some(Map("actionIdentification" -> JsString("384")))),
@@ -391,7 +391,7 @@ class CodeListsControllerSpec
 
   it should "return 500 Internal Server Error when there is an error fetching from the repository" in {
     when(
-      codeListsRepository.fetchCodeListEntries(
+      codeListsRepository.fetchEntries(
         equalTo(BC08),
         equalTo(None),
         equalTo(None),

--- a/it/test/uk/gov/hmrc/crdlcache/repositories/CodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/repositories/CodeListsRepositorySpec.scala
@@ -207,7 +207,7 @@ class CodeListsRepositorySpec
   private val codelistEntries =
     activeCodelistEntries ++ differentCodeListEntries ++ supersededCodeListEntries :+ invalidatedIoEntry :+ postDatedEntry
 
-  "CodeListsRepository.fetchCodeListEntryKeys" should "return entries that have been superseded" in withCodeListEntries(
+  "CodeListsRepository.fetchCodeListEntryKeys" should "return entries that have not been superseded" in withCodeListEntries(
     codelistEntries
   ) { session =>
     repository.fetchCodeListEntryKeys(session, BC08).map(_ must contain("BL"))

--- a/it/test/uk/gov/hmrc/crdlcache/repositories/CorrespondenceListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/repositories/CorrespondenceListsRepositorySpec.scala
@@ -1,0 +1,652 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.repositories
+
+import org.mongodb.scala.*
+import org.mongodb.scala.model.Filters.and
+import org.mongodb.scala.model.{Filters, Sorts}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.{Assertion, OptionValues}
+import play.api.libs.json.Json
+import uk.gov.hmrc.crdlcache.models.CodeListCode.E200
+import uk.gov.hmrc.crdlcache.models.CodeListEntry
+import uk.gov.hmrc.crdlcache.models.CorrespondenceListInstruction.{
+  InvalidateEntry,
+  RecordMissingEntry,
+  UpsertEntry
+}
+import uk.gov.hmrc.mongo.test.{
+  CleanMongoCollectionSupport,
+  IndexedMongoQueriesSupport,
+  PlayMongoRepositorySupport
+}
+import uk.gov.hmrc.mongo.transaction.TransactionConfiguration
+
+import java.time.Instant
+import scala.concurrent.duration.*
+import scala.concurrent.{ExecutionContext, Future}
+
+class CorrespondenceListsRepositorySpec
+  extends AnyFlatSpec
+  with PlayMongoRepositorySupport[CodeListEntry]
+  with CleanMongoCollectionSupport
+  with IndexedMongoQueriesSupport
+  with Matchers
+  with OptionValues
+  with ScalaFutures {
+
+  given TransactionConfiguration = TransactionConfiguration.strict
+  given ec: ExecutionContext     = ExecutionContext.global
+
+  override protected val repository: CorrespondenceListsRepository =
+    new CorrespondenceListsRepository(
+      mongoComponent
+    )
+
+  override given patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = 30.seconds, interval = 100.millis)
+
+  def withCorrespondenceListEntries(
+    entries: Seq[CodeListEntry]
+  )(test: ClientSession => Future[Assertion]): Unit = {
+    repository.collection.insertMany(entries).toFuture.futureValue
+    repository.withSessionAndTransaction(test).futureValue
+  }
+
+  private val activeEntries = List(
+    CodeListEntry(
+      E200,
+      "27101944",
+      "E430",
+      Instant.parse("2025-01-01T00:00:00Z"),
+      None,
+      Some(Instant.parse("2024-12-30T00:00:00Z")),
+      Json.obj(
+        "actionIdentification" -> "433"
+      )
+    ),
+    CodeListEntry(
+      E200,
+      "27101944",
+      "E440",
+      Instant.parse("2025-01-01T00:00:00Z"),
+      None,
+      Some(Instant.parse("2024-12-30T00:00:00Z")),
+      Json.obj(
+        "actionIdentification" -> "437"
+      )
+    ),
+    CodeListEntry(
+      E200,
+      "27102019",
+      "E430",
+      Instant.parse("2013-11-15T00:00:00Z"),
+      None,
+      Some(Instant.parse("2013-11-14T00:00:00Z")),
+      Json.obj(
+        "actionIdentification" -> "432"
+      )
+    ),
+    CodeListEntry(
+      E200,
+      "27102019",
+      "E440",
+      Instant.parse("2013-11-15T00:00:00Z"),
+      None,
+      Some(Instant.parse("2013-11-14T00:00:00Z")),
+      Json.obj(
+        "actionIdentification" -> "437"
+      )
+    )
+  )
+
+  private val supersededListEntries = List(
+    CodeListEntry(
+      E200,
+      "27101944",
+      "E420",
+      Instant.parse("2024-01-15T00:00:00Z"),
+      Some(Instant.parse("2024-01-17T00:00:00Z")),
+      Some(Instant.parse("2024-01-14T00:00:00Z")),
+      Json.obj(
+        "actionIdentification" -> "1234"
+      )
+    )
+  )
+
+  private val activeEntry = CodeListEntry(
+    E200,
+    "22060039",
+    "W200",
+    Instant.parse("2024-01-31T00:00:00Z"),
+    None,
+    Some(Instant.parse("2024-01-17T00:00:00Z")),
+    Json.obj(
+      "actionIdentification" -> "1024"
+    )
+  )
+
+  private val invalidatedEntry = CodeListEntry(
+    E200,
+    "27101944",
+    "E460",
+    Instant.parse("2024-01-31T00:00:00Z"),
+    Some(Instant.parse("2026-05-22T00:00:00Z")),
+    Some(Instant.parse("2026-05-21T00:00:00Z")),
+    Json.obj(
+      "actionIdentification" -> "9999"
+    )
+  )
+
+  private val existingE470Entry = CodeListEntry(
+    E200,
+    "27101944",
+    "E470",
+    Instant.parse("2025-06-05T00:00:00Z"),
+    None,
+    None,
+    Json.obj(
+      "actionIdentification" -> "7777"
+    )
+  )
+
+  private val postDatedE470Entry = CodeListEntry(
+    E200,
+    "27101944",
+    "E470",
+    Instant.parse("2026-06-05T00:00:00Z"),
+    None,
+    None,
+    Json.obj(
+      "actionIdentification" -> "9999"
+    )
+  )
+
+  private val newCorrespondenceEntry = CodeListEntry(
+    E200,
+    "22042196",
+    "I000",
+    Instant.parse("2024-01-31T00:00:00Z"),
+    None,
+    Some(Instant.parse("2024-01-17T00:00:00Z")),
+    Json.obj(
+      "actionIdentification" -> "1024"
+    )
+  )
+
+  private val entriesWithNoEndDate = activeEntries :+ postDatedE470Entry
+
+  private val correspondenceListEntries =
+    activeEntries ++ supersededListEntries :+ invalidatedEntry :+ postDatedE470Entry
+
+  "CorrespondenceListsRepository.fetchCorrespondenceKeys" should "return entries that have not been superseded" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { session =>
+    repository.fetchCorrespondenceKeys(session, E200).map(_ must contain("27101944" -> "E440"))
+  }
+
+  it should "not return entries that are invalidated" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { session =>
+    repository.fetchCorrespondenceKeys(session, E200).map(_ mustNot contain("27101944" -> "E460"))
+  }
+
+  it should "contain the active code list entry keys" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { session =>
+    repository
+      .fetchCorrespondenceKeys(session, E200)
+      .map {
+        _ mustBe entriesWithNoEndDate
+          .map(entry => (entry.key, entry.value))
+          .toSet
+      }
+  }
+
+  "CorrespondenceListsRepository.fetchCorrespondenceListEntries" should "return the codelist entries whose activeFrom date is before the requested date" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { _ =>
+    repository
+      .fetchCorrespondenceListEntries(
+        E200,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .map(_ must contain allElementsOf activeEntries)
+  }
+
+  it should "apply filtering of entries according to the supplied keys" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { _ =>
+    repository
+      .fetchCorrespondenceListEntries(
+        E200,
+        filterKeys = Some(Set("27101944")),
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .map(_ must contain allElementsOf activeEntries.take(2))
+  }
+
+  it should "not apply filtering of entries when the set of supplied keys is empty" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { _ =>
+    repository
+      .fetchCorrespondenceListEntries(
+        E200,
+        filterKeys = Some(Set.empty),
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .map(_ must contain allElementsOf activeEntries)
+  }
+
+  it should "not return entries that have been superseded" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { _ =>
+    repository
+      .fetchCorrespondenceListEntries(
+        E200,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .map(_ must contain noElementsOf supersededListEntries)
+  }
+
+  it should "not return entries that are not yet active" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { _ =>
+    repository
+      .fetchCorrespondenceListEntries(
+        E200,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .map(_ mustNot contain(postDatedE470Entry))
+  }
+
+  it should "return entries that have been invalidated if the invalidation date is in the future" in withCorrespondenceListEntries(
+    correspondenceListEntries
+  ) { _ =>
+    repository
+      .fetchCorrespondenceListEntries(
+        E200,
+        filterKeys = None,
+        activeAt = Instant.parse("2025-06-05T00:00:00Z")
+      )
+      .map(_ must contain(invalidatedEntry))
+  }
+
+  "CorrespondenceListsRepository.executeInstructions" should "invalidate existing entries" in withCorrespondenceListEntries(
+    activeEntries :+ activeEntry
+  ) { session =>
+    for {
+      _ <- repository
+        .executeInstructions(
+          session,
+          List(
+            InvalidateEntry(
+              activeEntry.copy(activeFrom = Instant.parse("2025-05-22T00:00:00Z"))
+            )
+          )
+        )
+
+      entries <- repository.collection
+        .find(
+          session,
+          and(
+            Filters.eq("codeListCode", E200.code),
+            Filters.eq("key", activeEntry.key),
+            Filters.eq("value", activeEntry.value)
+          )
+        )
+        .toFuture()
+
+    } yield entries mustBe Seq(
+      activeEntry.copy(activeTo = Some(Instant.parse("2025-05-22T00:00:00Z")))
+    )
+  }
+
+  it should "invalidate existing entries when the activation date is the same as the existing record" in withCorrespondenceListEntries(
+    activeEntries :+ activeEntry
+  ) { session =>
+    for {
+      _ <- repository
+        .executeInstructions(
+          session,
+          List(InvalidateEntry(activeEntry))
+        )
+
+      entries <- repository.collection
+        .find(
+          session,
+          and(
+            Filters.eq("codeListCode", E200.code),
+            Filters.eq("key", activeEntry.key),
+            Filters.eq("value", activeEntry.value)
+          )
+        )
+        .toFuture()
+
+    } yield entries mustBe Seq(activeEntry.copy(activeTo = Some(activeEntry.activeFrom)))
+  }
+
+  it should "invalidate missing entries" in withCorrespondenceListEntries(
+    activeEntries :+ activeEntry
+  ) { session =>
+    for {
+      _ <- repository
+        .executeInstructions(
+          session,
+          List(
+            RecordMissingEntry(
+              E200,
+              activeEntry.key,
+              activeEntry.value,
+              Instant.parse("2025-05-22T00:00:00Z")
+            )
+          )
+        )
+
+      entries <- repository.collection
+        .find(
+          session,
+          and(
+            Filters.eq("codeListCode", E200.code),
+            Filters.eq("key", activeEntry.key),
+            Filters.eq("value", activeEntry.value)
+          )
+        )
+        .toFuture()
+
+    } yield entries mustBe Seq(
+      activeEntry.copy(activeTo = Some(Instant.parse("2025-05-22T00:00:00Z")))
+    )
+  }
+
+  it should "invalidate missing entries when the activation date is the same as the existing one" in withCorrespondenceListEntries(
+    activeEntries :+ activeEntry
+  ) { session =>
+    for {
+      _ <- repository
+        .executeInstructions(
+          session,
+          List(
+            RecordMissingEntry(
+              E200,
+              activeEntry.key,
+              activeEntry.value,
+              activeEntry.activeFrom
+            )
+          )
+        )
+
+      entries <- repository.collection
+        .find(
+          session,
+          and(
+            Filters.eq("codeListCode", E200.code),
+            Filters.eq("key", activeEntry.key),
+            Filters.eq("value", activeEntry.value)
+          )
+        )
+        .toFuture()
+
+    } yield entries mustBe Seq(activeEntry.copy(activeTo = Some(activeEntry.activeFrom)))
+  }
+
+  it should "supersede and invalidate existing entries" in withCorrespondenceListEntries(
+    activeEntries :+ activeEntry
+  ) { session =>
+    val newActiveFrom = Instant.parse("2024-02-01T00:00:00Z")
+
+    for {
+      _ <- repository
+        .executeInstructions(
+          session,
+          List(UpsertEntry(activeEntry.copy(activeFrom = newActiveFrom)))
+        )
+
+      entries <- repository.collection
+        .find(
+          session,
+          and(
+            Filters.eq("codeListCode", E200.code),
+            Filters.eq("key", activeEntry.key),
+            Filters.eq("value", activeEntry.value)
+          )
+        )
+        .sort(Sorts.ascending("activeFrom"))
+        .toFuture()
+
+    } yield entries mustBe Seq(
+      activeEntry.copy(activeTo = Some(newActiveFrom)),
+      activeEntry.copy(activeFrom = newActiveFrom)
+    )
+  }
+
+  it should "create a new entry when a new key->value mapping is encountered" in withCorrespondenceListEntries(
+    activeEntries
+  ) { session =>
+    for {
+      _ <- repository
+        .executeInstructions(
+          session,
+          List(UpsertEntry(newCorrespondenceEntry))
+        )
+
+      entries <- repository.collection
+        .find(
+          session,
+          and(
+            Filters.eq("codeListCode", E200.code),
+            Filters.eq("key", newCorrespondenceEntry.key)
+          )
+        )
+        .toFuture()
+
+    } yield entries mustBe Seq(newCorrespondenceEntry)
+  }
+
+  it should "replace existing entries with same active from date" in withCorrespondenceListEntries(
+    activeEntries :+ activeEntry
+  ) { session =>
+    val updatedEntry = activeEntry.copy(
+      properties = Json.obj(
+        "actionIdentification" -> "2499"
+      )
+    )
+
+    for {
+      _ <- repository
+        .executeInstructions(
+          session,
+          List(UpsertEntry(updatedEntry))
+        )
+
+      entries <- repository.collection
+        .find(
+          session,
+          and(
+            Filters.eq("codeListCode", E200.code),
+            Filters.eq("key", activeEntry.key)
+          )
+        )
+        .sort(Sorts.ascending("activeFrom"))
+        .toFuture()
+
+    } yield entries mustBe Seq(updatedEntry)
+  }
+
+  it should "upsert entries in the order of their active from date" in {
+    repository.withSessionAndTransaction { session =>
+      for {
+        _ <- repository
+          .executeInstructions(
+            session,
+            List(
+              InvalidateEntry(
+                activeEntry.copy(activeFrom = Instant.parse("2025-05-22T00:00:00Z"))
+              ),
+              UpsertEntry(postDatedE470Entry),
+              RecordMissingEntry(
+                E200,
+                newCorrespondenceEntry.key,
+                newCorrespondenceEntry.value,
+                Instant.parse("2025-01-17T00:00:00Z")
+              ),
+              UpsertEntry(existingE470Entry),
+              UpsertEntry(newCorrespondenceEntry)
+            )
+          )
+
+        entries <- repository.collection
+          .find(
+            session,
+            and(
+              Filters.eq("codeListCode", E200.code)
+            )
+          )
+          .sort(Sorts.ascending("key", "value", "activeFrom"))
+          .toFuture()
+
+      } yield entries mustBe Seq(
+        newCorrespondenceEntry.copy(activeTo = Some(Instant.parse("2025-01-17T00:00:00Z"))),
+        existingE470Entry.copy(activeTo = Some(postDatedE470Entry.activeFrom)),
+        postDatedE470Entry
+      )
+    }.futureValue
+  }
+  "CorrespondenceListsRepository.saveCorrespondenceListEntries" should "save the provided codelist entries" in {
+    val newEntries = List(
+      CodeListEntry(
+        E200,
+        "27101944",
+        "E430",
+        Instant.parse("2025-01-01T00:00:00Z"),
+        None,
+        Some(Instant.parse("2024-12-30T00:00:00Z")),
+        Json.obj(
+          "actionIdentification" -> "433"
+        )
+      ),
+      CodeListEntry(
+        E200,
+        "27101944",
+        "E440",
+        Instant.parse("2025-01-01T00:00:00Z"),
+        None,
+        Some(Instant.parse("2024-12-30T00:00:00Z")),
+        Json.obj(
+          "actionIdentification" -> "437"
+        )
+      ),
+      CodeListEntry(
+        E200,
+        "27102019",
+        "E430",
+        Instant.parse("2013-11-15T00:00:00Z"),
+        None,
+        Some(Instant.parse("2013-11-14T00:00:00Z")),
+        Json.obj(
+          "actionIdentification" -> "432"
+        )
+      ),
+      CodeListEntry(
+        E200,
+        "27102019",
+        "E440",
+        Instant.parse("2013-11-15T00:00:00Z"),
+        None,
+        Some(Instant.parse("2013-11-14T00:00:00Z")),
+        Json.obj(
+          "actionIdentification" -> "437"
+        )
+      )
+    )
+
+    repository.withSessionAndTransaction { session =>
+      repository.saveCorrespondenceListEntries(session, E200, newEntries)
+    }.futureValue
+
+    find(
+      Filters.equal("codeListCode", E200.code)
+    ).futureValue must contain theSameElementsAs newEntries
+  }
+
+  it should "remove existing entries when new entries are saved" in {
+    val existingEntries = List(
+      CodeListEntry(
+        E200,
+        "27101944",
+        "E440",
+        Instant.parse("2025-01-01T00:00:00Z"),
+        None,
+        Some(Instant.parse("2024-12-30T00:00:00Z")),
+        Json.obj(
+          "actionIdentification" -> "437"
+        )
+      ),
+      CodeListEntry(
+        E200,
+        "27102019",
+        "E430",
+        Instant.parse("2013-11-15T00:00:00Z"),
+        None,
+        Some(Instant.parse("2013-11-14T00:00:00Z")),
+        Json.obj(
+          "actionIdentification" -> "432"
+        )
+      )
+    )
+
+    repository.collection.insertMany(existingEntries).toFuture().futureValue
+
+    val newEntries = List(
+      CodeListEntry(
+        E200,
+        "27101944",
+        "E430",
+        Instant.parse("2025-01-01T00:00:00Z"),
+        None,
+        Some(Instant.parse("2024-12-30T00:00:00Z")),
+        Json.obj(
+          "actionIdentification" -> "433"
+        )
+      ),
+      CodeListEntry(
+        E200,
+        "27102019",
+        "E440",
+        Instant.parse("2013-11-15T00:00:00Z"),
+        None,
+        Some(Instant.parse("2013-11-14T00:00:00Z")),
+        Json.obj(
+          "actionIdentification" -> "437"
+        )
+      )
+    )
+
+    repository.withSessionAndTransaction { session =>
+      repository.saveCorrespondenceListEntries(session, E200, newEntries)
+    }.futureValue
+
+    find(
+      Filters.equal("codeListCode", E200.code)
+    ).futureValue must contain theSameElementsAs newEntries
+  }
+}

--- a/it/test/uk/gov/hmrc/crdlcache/repositories/CorrespondenceListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/repositories/CorrespondenceListsRepositorySpec.scala
@@ -195,23 +195,23 @@ class CorrespondenceListsRepositorySpec
   private val correspondenceListEntries =
     activeEntries ++ supersededListEntries :+ invalidatedEntry :+ postDatedE470Entry
 
-  "CorrespondenceListsRepository.fetchCorrespondenceKeys" should "return entries that have not been superseded" in withCorrespondenceListEntries(
+  "CorrespondenceListsRepository.fetchEntryKeys" should "return entries that have not been superseded" in withCorrespondenceListEntries(
     correspondenceListEntries
   ) { session =>
-    repository.fetchCorrespondenceKeys(session, E200).map(_ must contain("27101944" -> "E440"))
+    repository.fetchEntryKeys(session, E200).map(_ must contain("27101944" -> "E440"))
   }
 
   it should "not return entries that are invalidated" in withCorrespondenceListEntries(
     correspondenceListEntries
   ) { session =>
-    repository.fetchCorrespondenceKeys(session, E200).map(_ mustNot contain("27101944" -> "E460"))
+    repository.fetchEntryKeys(session, E200).map(_ mustNot contain("27101944" -> "E460"))
   }
 
   it should "contain the active code list entry keys" in withCorrespondenceListEntries(
     correspondenceListEntries
   ) { session =>
     repository
-      .fetchCorrespondenceKeys(session, E200)
+      .fetchEntryKeys(session, E200)
       .map {
         _ mustBe entriesWithNoEndDate
           .map(entry => (entry.key, entry.value))
@@ -219,11 +219,11 @@ class CorrespondenceListsRepositorySpec
       }
   }
 
-  "CorrespondenceListsRepository.fetchCorrespondenceListEntries" should "return the codelist entries whose activeFrom date is before the requested date" in withCorrespondenceListEntries(
+  "CorrespondenceListsRepository.fetchEntries" should "return the codelist entries whose activeFrom date is before the requested date" in withCorrespondenceListEntries(
     correspondenceListEntries
   ) { _ =>
     repository
-      .fetchCorrespondenceListEntries(
+      .fetchEntries(
         E200,
         filterKeys = None,
         filterProperties = None,
@@ -236,7 +236,7 @@ class CorrespondenceListsRepositorySpec
     correspondenceListEntries
   ) { _ =>
     repository
-      .fetchCorrespondenceListEntries(
+      .fetchEntries(
         E200,
         filterKeys = Some(Set("27101944")),
         filterProperties = None,
@@ -249,7 +249,7 @@ class CorrespondenceListsRepositorySpec
     correspondenceListEntries
   ) { _ =>
     repository
-      .fetchCorrespondenceListEntries(
+      .fetchEntries(
         E200,
         filterKeys = Some(Set.empty),
         filterProperties = None,
@@ -262,7 +262,7 @@ class CorrespondenceListsRepositorySpec
     correspondenceListEntries
   ) { _ =>
     repository
-      .fetchCorrespondenceListEntries(
+      .fetchEntries(
         E200,
         filterKeys = None,
         filterProperties = None,
@@ -275,7 +275,7 @@ class CorrespondenceListsRepositorySpec
     correspondenceListEntries
   ) { _ =>
     repository
-      .fetchCorrespondenceListEntries(
+      .fetchEntries(
         E200,
         filterKeys = None,
         filterProperties = None,
@@ -288,7 +288,7 @@ class CorrespondenceListsRepositorySpec
     correspondenceListEntries
   ) { _ =>
     repository
-      .fetchCorrespondenceListEntries(
+      .fetchEntries(
         E200,
         filterKeys = None,
         filterProperties = None,
@@ -301,7 +301,7 @@ class CorrespondenceListsRepositorySpec
     correspondenceListEntries
   ) { _ =>
     repository
-      .fetchCorrespondenceListEntries(
+      .fetchEntries(
         E200,
         filterKeys = None,
         filterProperties = Some(Map("actionIdentification" -> JsString("437"))),
@@ -314,7 +314,7 @@ class CorrespondenceListsRepositorySpec
     correspondenceListEntries
   ) { _ =>
     repository
-      .fetchCorrespondenceListEntries(
+      .fetchEntries(
         E200,
         filterKeys = Some(Set("27101944")),
         filterProperties = Some(Map("actionIdentification" -> JsString("437"))),
@@ -612,7 +612,7 @@ class CorrespondenceListsRepositorySpec
     )
 
     repository.withSessionAndTransaction { session =>
-      repository.saveCorrespondenceListEntries(session, E200, newEntries)
+      repository.saveEntries(session, E200, newEntries)
     }.futureValue
 
     find(
@@ -674,7 +674,7 @@ class CorrespondenceListsRepositorySpec
     )
 
     repository.withSessionAndTransaction { session =>
-      repository.saveCorrespondenceListEntries(session, E200, newEntries)
+      repository.saveEntries(session, E200, newEntries)
     }.futureValue
 
     find(

--- a/test/uk/gov/hmrc/crdlcache/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/config/AppConfigSpec.scala
@@ -36,13 +36,22 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
         "microservice.services.dps-api.customs-offices-path" -> "views/iv_crdl_customs_office",
         "microservice.services.dps-api.clientId"             -> "abc123",
         "microservice.services.dps-api.clientSecret"         -> "def456",
+        "last-updated-date.default"                          -> "2025-05-29",
         "import-codelists.schedule"                          -> "*/10 * * * * ?",
+        "import-correspondence-lists.schedule"               -> "*/10 * * * * ?",
         "import-offices.schedule"                            -> "*/10 * * * * ?",
-        "import-codelists.last-updated-date.default"         -> "2025-05-29",
         "import-codelists.codelists" -> List(
           Map("code" -> "BC08", "origin"  -> "SEED", "keyProperty"  -> "CountryCode"),
           Map("code" -> "BC36", "origin"  -> "SEED", "keyProperty"  -> "ExciseProductCode"),
           Map("code" -> "CL380", "origin" -> "CSRD2", "keyProperty" -> "DocumentType")
+        ),
+        "import-correspondence-lists.correspondence-lists" -> List(
+          Map(
+            "code"          -> "E200",
+            "origin"        -> "SEED",
+            "keyProperty"   -> "CnCode",
+            "valueProperty" -> "ExciseProductCode"
+          )
         )
       )
     )
@@ -57,11 +66,15 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
 
     appConfig.importCodeListsSchedule mustBe "*/10 * * * * ?"
     appConfig.importOfficesSchedule mustBe "*/10 * * * * ?"
+    appConfig.importCorrespondenceListsSchedule mustBe "*/10 * * * * ?"
     appConfig.defaultLastUpdated mustBe LocalDate.of(2025, 5, 29)
     appConfig.codeListConfigs mustBe List(
       CodeListConfig(BC08, SEED, "CountryCode"),
       CodeListConfig(BC36, SEED, "ExciseProductCode"),
       CodeListConfig(Unknown("CL380"), CSRD2, "DocumentType")
+    )
+    appConfig.correspondenceListConfigs mustBe List(
+      CorrespondenceListConfig(E200, SEED, "CnCode", "ExciseProductCode")
     )
   }
 
@@ -77,6 +90,7 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
 
     appConfig.importOfficesSchedule mustBe "0 0 4 * * ?"
     appConfig.importCodeListsSchedule mustBe "0 0 4 * * ?"
+    appConfig.importCorrespondenceListsSchedule mustBe "0 0 4 * * ?"
     appConfig.defaultLastUpdated mustBe LocalDate.of(2025, 3, 12)
     appConfig.codeListConfigs mustBe List(
       CodeListConfig(BC01, SEED, "EvidenceTypeCode"),
@@ -108,5 +122,6 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
       CodeListConfig(BC108, SEED, "ManualClosureRejectionReasonCode"),
       CodeListConfig(BC109, SEED, "NationalAdministrationDegreePlatoCode")
     )
+    appConfig.correspondenceListConfigs mustBe List.empty
   }
 }

--- a/test/uk/gov/hmrc/crdlcache/models/CodeListSnapshotEntrySpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/models/CodeListSnapshotEntrySpec.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.crdlcache.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.libs.json.Json
-import uk.gov.hmrc.crdlcache.config.CodeListConfig
-import uk.gov.hmrc.crdlcache.models.CodeListCode.BC08
+import uk.gov.hmrc.crdlcache.config.{CodeListConfig, CorrespondenceListConfig}
+import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, E200}
 import uk.gov.hmrc.crdlcache.models.CodeListOrigin.SEED
 import uk.gov.hmrc.crdlcache.models.Operation.{Create, Update}
 import uk.gov.hmrc.crdlcache.models.dps.codeList
@@ -36,6 +36,7 @@ import java.time.Instant
 
 class CodeListSnapshotEntrySpec extends AnyFlatSpec with Matchers with TestData {
   private val BC08Config = CodeListConfig(BC08, SEED, "CountryCode")
+  private val E200Config = CorrespondenceListConfig(E200, SEED, "CnCode", "ExciseProductCode")
 
   private val convertedEntry = CodeListSnapshotEntry(
     "AW",
@@ -66,6 +67,15 @@ class CodeListSnapshotEntrySpec extends AnyFlatSpec with Matchers with TestData 
       CodeListSnapshotEntry.fromDpsEntry(
         BC08Config,
         codeList.CodeListEntry(List(DataItem(BC08Config.keyProperty, Some("AW"))), List.empty)
+      )
+    }
+  }
+
+  it should "fail when importing a correspondence list if the value property is missing" in {
+    assertThrows[RequiredDataItemMissing] {
+      CodeListSnapshotEntry.fromDpsEntry(
+        E200Config,
+        codeList.CodeListEntry(List(DataItem(E200Config.keyProperty, Some("27101944"))), List.empty)
       )
     }
   }

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
@@ -1,0 +1,774 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.schedulers
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.mockito.ArgumentMatchers.{any, anyLong, eq as equalTo}
+import org.mockito.Mockito
+import org.mockito.Mockito.*
+import org.mongodb.scala.{ClientSession, MongoClient, MongoDatabase, SingleObservable}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.Json
+import uk.gov.hmrc.crdlcache.config.{AppConfig, CorrespondenceListConfig}
+import uk.gov.hmrc.crdlcache.connectors.DpsConnector
+import uk.gov.hmrc.crdlcache.models.*
+import uk.gov.hmrc.crdlcache.models.CodeListCode.E200
+import uk.gov.hmrc.crdlcache.models.CodeListOrigin.SEED
+import uk.gov.hmrc.crdlcache.models.CorrespondenceListInstruction.{
+  InvalidateEntry,
+  RecordMissingEntry,
+  UpsertEntry
+}
+import uk.gov.hmrc.crdlcache.models.Operation.Update
+import uk.gov.hmrc.crdlcache.models.dps.RelationType.{Next, Prev, Self}
+import uk.gov.hmrc.crdlcache.models.dps.codeList.{CodeListResponse, DataItem, LanguageDescription}
+import uk.gov.hmrc.crdlcache.models.dps.{Relation, codeList}
+import uk.gov.hmrc.crdlcache.models.errors.MongoError
+import uk.gov.hmrc.crdlcache.repositories.{CorrespondenceListsRepository, LastUpdatedRepository}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.lock.{Lock, MongoLockRepository}
+
+import java.time.{Clock, Instant, LocalDate, ZoneOffset}
+import scala.concurrent.{ExecutionContext, Future}
+
+class ImportCorrespondenceListsJobSpec
+  extends AnyFlatSpec
+  with Matchers
+  with MockitoSugar
+  with ScalaFutures
+  with IntegrationPatience
+  with BeforeAndAfterEach {
+  private val mongoComponent                = mock[MongoComponent]
+  private val mongoClient                   = mock[MongoClient]
+  private val mongoDatabase                 = mock[MongoDatabase]
+  private val clientSession                 = mock[ClientSession]
+  private val lockRepository                = mock[MongoLockRepository]
+  private val lastUpdatedRepository         = mock[LastUpdatedRepository]
+  private val correspondenceListsRepository = mock[CorrespondenceListsRepository]
+  private val dpsConnector                  = mock[DpsConnector]
+  private val appConfig                     = mock[AppConfig]
+  private val fixedInstant                  = Instant.parse("2025-06-03T00:00:00Z")
+  private val clock                         = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+
+  given ActorSystem      = ActorSystem("test")
+  given ExecutionContext = ExecutionContext.global
+
+  private val correspondenceListsJob = new ImportCorrespondenceListsJob(
+    mongoComponent,
+    lockRepository,
+    lastUpdatedRepository,
+    correspondenceListsRepository,
+    dpsConnector,
+    appConfig,
+    clock
+  )
+
+  private val snapshotsPage1 = CodeListResponse(
+    List(
+      codeList.CodeListSnapshot(
+        E200,
+        "CorrespondenceCnCodeExciseProduct",
+        1,
+        List(
+          codeList.CodeListEntry(
+            List(
+              codeList.DataItem("CnCode", Some("27101944")),
+              codeList.DataItem("ExciseProductCode", Some("E430")),
+              codeList.DataItem("Action_Operation", Some("C")),
+              codeList.DataItem("Action_ActivationDate", Some("01-01-2025")),
+              codeList.DataItem("Action_ActionIdentification", Some("433")),
+              codeList.DataItem("Action_ResponsibleDataManager", None),
+              codeList.DataItem("Action_ModificationDateAndTime", Some("30-12-2024"))
+            ),
+            List(LanguageDescription("en", "No english language description available"))
+          ),
+          codeList.CodeListEntry(
+            List(
+              codeList.DataItem("CnCode", Some("27101944")),
+              codeList.DataItem("ExciseProductCode", Some("E440")),
+              codeList.DataItem("Action_Operation", Some("C")),
+              codeList.DataItem("Action_ActivationDate", Some("01-01-2025")),
+              codeList.DataItem("Action_ActionIdentification", Some("437")),
+              codeList.DataItem("Action_ResponsibleDataManager", None),
+              codeList.DataItem("Action_ModificationDateAndTime", Some("30-12-2024"))
+            ),
+            List(codeList.LanguageDescription("en", "No english language description available"))
+          ),
+          codeList.CodeListEntry(
+            List(
+              codeList.DataItem("CnCode", Some("27102019")),
+              codeList.DataItem("ExciseProductCode", Some("E430")),
+              codeList.DataItem("Action_Operation", Some("U")),
+              codeList.DataItem("Action_ActivationDate", Some("15-11-2013")),
+              codeList.DataItem("Action_ActionIdentification", Some("432")),
+              codeList.DataItem("Action_ResponsibleDataManager", None),
+              codeList.DataItem("Action_ModificationDateAndTime", Some("14-11-2013"))
+            ),
+            List(LanguageDescription("en", "No english language description available"))
+          ),
+          codeList.CodeListEntry(
+            List(
+              codeList.DataItem("CnCode", Some("27102019")),
+              codeList.DataItem("ExciseProductCode", Some("E440")),
+              codeList.DataItem("Action_Operation", Some("U")),
+              codeList.DataItem("Action_ActivationDate", Some("15-11-2013")),
+              codeList.DataItem("Action_ActionIdentification", Some("437")),
+              codeList.DataItem("Action_ResponsibleDataManager", None),
+              codeList.DataItem("Action_ModificationDateAndTime", Some("14-11-2013"))
+            ),
+            List(codeList.LanguageDescription("en", "No english language description available"))
+          )
+        )
+      )
+    ),
+    List(
+      Relation(
+        Self,
+        "https://localhost:9443/server/central_reference_data_library/ws_iv_crdl_reference_data/views/iv_crdl_reference_data?%24orderby=snapshotversion+ASC&code_list_code=E200&last_updated_date=2025-05-28T00%3A00%3A00Z&%24count=10"
+      ),
+      dps.Relation(
+        Next,
+        "?%24start_index=10&%24orderby=snapshotversion+ASC&code_list_code=E200&last_updated_date=2025-05-28T00%3A00%3A00Z&%24count=10"
+      )
+    )
+  )
+
+  private val snapshotsPage2 = codeList.CodeListResponse(
+    List(
+      codeList.CodeListSnapshot(
+        E200,
+        "CorrespondenceCnCodeExciseProduct",
+        2,
+        List(
+          codeList.CodeListEntry(
+            List(
+              codeList.DataItem("CnCode", Some("27101944")),
+              codeList.DataItem("ExciseProductCode", Some("E430")),
+              codeList.DataItem("Action_Operation", Some("I")),
+              codeList.DataItem("Action_ActivationDate", Some("02-01-2025")),
+              codeList.DataItem("Action_ActionIdentification", Some("2412")),
+              codeList.DataItem("Action_ResponsibleDataManager", None),
+              codeList.DataItem("Action_ModificationDateAndTime", Some("01-01-2025"))
+            ),
+            List(LanguageDescription("en", "No english language description available"))
+          ),
+          codeList.CodeListEntry(
+            List(
+              codeList.DataItem("CnCode", Some("27101944")),
+              codeList.DataItem("ExciseProductCode", Some("E440")),
+              codeList.DataItem("Action_Operation", Some("U")),
+              codeList.DataItem("Action_ActivationDate", Some("01-01-2025")),
+              codeList.DataItem("Action_ActionIdentification", Some("2413")),
+              codeList.DataItem("Action_ResponsibleDataManager", None),
+              codeList.DataItem("Action_ModificationDateAndTime", Some("30-12-2024"))
+            ),
+            List(codeList.LanguageDescription("en", "No english language description available"))
+          ),
+          codeList.CodeListEntry(
+            List(
+              codeList.DataItem("CnCode", Some("27102019")),
+              codeList.DataItem("ExciseProductCode", Some("E440")),
+              codeList.DataItem("Action_Operation", Some("U")),
+              codeList.DataItem("Action_ActivationDate", Some("15-11-2013")),
+              codeList.DataItem("Action_ActionIdentification", Some("437")),
+              codeList.DataItem("Action_ResponsibleDataManager", None),
+              codeList.DataItem("Action_ModificationDateAndTime", Some("14-11-2013"))
+            ),
+            List(LanguageDescription("en", "No english language description available"))
+          )
+        )
+      )
+    ),
+    List(
+      dps.Relation(
+        Self,
+        "https://localhost:9443/server/central_reference_data_library/ws_iv_crdl_reference_data/views/iv_crdl_reference_data?%24orderby=snapshotversion+ASC&code_list_code=E200&%24start_index=10&last_updated_date=2025-05-28T00%3A00%3A00Z&%24count=10"
+      ),
+      dps.Relation(
+        Prev,
+        "?%24orderby=snapshotversion+ASC&code_list_code=E200&last_updated_date=2025-05-28T00%3A00%3A00Z&%24count=10"
+      )
+    )
+  )
+
+  override def beforeEach(): Unit = {
+    reset(
+      mongoComponent,
+      mongoClient,
+      mongoDatabase,
+      clientSession,
+      lockRepository,
+      lastUpdatedRepository,
+      correspondenceListsRepository,
+      dpsConnector,
+      appConfig
+    )
+
+    // Job lock
+    val mockLock = mock[Lock]
+    when(lockRepository.takeLock(any(), any(), any())).thenReturn(Future.successful(Some(mockLock)))
+    when(lockRepository.releaseLock(any(), any())).thenReturn(Future.unit)
+
+    // Transactions
+    when(mongoComponent.client).thenReturn(mongoClient)
+    when(mongoComponent.database).thenReturn(mongoDatabase)
+    when(mongoClient.startSession(any())).thenReturn(SingleObservable(clientSession))
+    when(clientSession.commitTransaction())
+      .thenAnswer(_ => Source.empty[Void].runWith(Sink.asPublisher(fanout = false)))
+    when(clientSession.abortTransaction())
+      .thenAnswer(_ => Source.empty[Void].runWith(Sink.asPublisher(fanout = false)))
+  }
+
+  "ImportCorrespondenceListsJob.importStaticData" should "import the static E200 codelist data" in {
+    when(correspondenceListsRepository.saveCorrespondenceListEntries(any(), any(), any()))
+      .thenReturn(Future.unit)
+
+    correspondenceListsJob.importStaticData().futureValue
+
+    verify(correspondenceListsRepository, times(1)).saveCorrespondenceListEntries(
+      equalTo(clientSession),
+      equalTo(E200),
+      any()
+    )
+
+    verify(clientSession, times(1)).commitTransaction()
+  }
+
+  it should "roll back when there is an error during the import process" in {
+    when(correspondenceListsRepository.saveCorrespondenceListEntries(any(), any(), any()))
+      .thenReturn(Future.failed(new RuntimeException("Boom!")))
+
+    assertThrows[RuntimeException] {
+      correspondenceListsJob.importStaticData().futureValue
+    }
+
+    verify(correspondenceListsRepository, times(1)).saveCorrespondenceListEntries(
+      equalTo(clientSession),
+      equalTo(E200),
+      any()
+    )
+
+    verify(clientSession, times(1)).abortTransaction()
+  }
+
+  "ImportCorrespondenceListsJob.importCorrespondenceLists" should "import the configured correspondence lists when there is no last updated date stored" in {
+    val lastUpdated        = LocalDate.of(2025, 3, 12)
+    val lastUpdatedInstant = lastUpdated.atStartOfDay(ZoneOffset.UTC).toInstant
+
+    // Last updated date
+    when(appConfig.defaultLastUpdated).thenReturn(lastUpdated)
+
+    when(lastUpdatedRepository.fetchLastUpdated(any())).thenReturn(Future.successful(None))
+
+    when(
+      lastUpdatedRepository.setLastUpdated(
+        equalTo(clientSession),
+        any(),
+        anyLong(),
+        equalTo(fixedInstant)
+      )
+    )
+      .thenReturn(Future.unit)
+
+    // Correspondence list manipulation
+    when(
+      correspondenceListsRepository.fetchCorrespondenceKeys(equalTo(clientSession), equalTo(E200))
+    )
+      .thenReturn(Future.successful(Set.empty[(String, String)]))
+      .thenReturn(
+        Future.successful(
+          Set(
+            "27101944" -> "E430",
+            "27101944" -> "E440",
+            "27102019" -> "E430",
+            "27102019" -> "E440"
+          )
+        )
+      )
+
+    when(
+      correspondenceListsRepository.saveCorrespondenceListEntries(
+        equalTo(clientSession),
+        equalTo(E200),
+        any()
+      )
+    ).thenReturn(Future.unit)
+
+    // Correspondence list configuration
+    when(appConfig.correspondenceListConfigs).thenReturn(
+      List(
+        CorrespondenceListConfig(E200, SEED, "CnCode", "ExciseProductCode")
+      )
+    )
+
+    // DPS connector responses
+    when(
+      dpsConnector.fetchCodeListSnapshots(equalTo(E200), equalTo(lastUpdatedInstant))(using any())
+    )
+      .thenReturn(Source(List(snapshotsPage1, snapshotsPage2)))
+
+    // Instruction execution
+    when(
+      correspondenceListsRepository.executeInstructions(
+        equalTo(clientSession),
+        any[List[CorrespondenceListInstruction]]
+      )
+    )
+      .thenReturn(Future.unit)
+
+    correspondenceListsJob.importCorrespondenceLists().futureValue
+
+    verify(correspondenceListsRepository, times(2)).executeInstructions(
+      equalTo(clientSession),
+      any()
+    )
+
+    verify(correspondenceListsRepository, times(2))
+      .executeInstructions(equalTo(clientSession), any())
+
+    // There are two snapshots for E200
+    verify(lastUpdatedRepository, times(2)).setLastUpdated(
+      equalTo(clientSession),
+      equalTo(E200),
+      anyLong(),
+      equalTo(fixedInstant)
+    )
+
+    // The (temporary) static data should have been saved
+    verify(correspondenceListsRepository, times(1)).saveCorrespondenceListEntries(
+      equalTo(clientSession),
+      equalTo(E200),
+      any()
+    )
+
+    // Two snapshots plus the static data should have been committed
+    verify(clientSession, times(3)).commitTransaction()
+  }
+
+  it should "import the configured correspondence lists when there is a last updated record stored" in {
+    // Last updated date
+    val storedInstant = Instant.parse("2025-03-13T00:00:00Z")
+
+    when(appConfig.defaultLastUpdated).thenReturn(LocalDate.of(2025, 3, 12))
+
+    when(lastUpdatedRepository.fetchLastUpdated(E200))
+      .thenReturn(Future.successful(Some(LastUpdated(E200, 1, storedInstant))))
+
+    when(
+      lastUpdatedRepository.setLastUpdated(
+        equalTo(clientSession),
+        any(),
+        anyLong(),
+        equalTo(fixedInstant)
+      )
+    )
+      .thenReturn(Future.unit)
+
+    // Correspondence list manipulation
+    when(
+      correspondenceListsRepository.fetchCorrespondenceKeys(equalTo(clientSession), equalTo(E200))
+    )
+      .thenReturn(Future.successful(Set.empty[(String, String)]))
+      .thenReturn(
+        Future.successful(
+          Set(
+            "27101944" -> "E430",
+            "27101944" -> "E440",
+            "27102019" -> "E430",
+            "27102019" -> "E440"
+          )
+        )
+      )
+
+    when(
+      correspondenceListsRepository.saveCorrespondenceListEntries(
+        equalTo(clientSession),
+        equalTo(E200),
+        any()
+      )
+    ).thenReturn(Future.unit)
+
+    // Correspondence list configuration
+    when(appConfig.correspondenceListConfigs).thenReturn(
+      List(
+        CorrespondenceListConfig(E200, SEED, "CnCode", "ExciseProductCode")
+      )
+    )
+
+    // DPS connector responses
+    when(
+      dpsConnector.fetchCodeListSnapshots(equalTo(E200), equalTo(storedInstant))(using any())
+    )
+      .thenReturn(Source(List(snapshotsPage1, snapshotsPage2)))
+
+    // Instruction execution
+    when(
+      correspondenceListsRepository.executeInstructions(
+        equalTo(clientSession),
+        any[List[CorrespondenceListInstruction]]
+      )
+    )
+      .thenReturn(Future.unit)
+
+    correspondenceListsJob.importCorrespondenceLists().futureValue
+
+    // There are two snapshots for E200, but we already have snapshot 1
+    verify(correspondenceListsRepository, times(1))
+      .executeInstructions(equalTo(clientSession), any())
+
+    verify(lastUpdatedRepository, times(1)).setLastUpdated(
+      equalTo(clientSession),
+      equalTo(E200),
+      equalTo(2L),
+      equalTo(fixedInstant)
+    )
+
+    // The (temporary) static data should have been saved
+    verify(correspondenceListsRepository, times(1)).saveCorrespondenceListEntries(
+      equalTo(clientSession),
+      equalTo(E200),
+      any()
+    )
+
+    // Only one snapshot plus the static data should have been committed
+    verify(clientSession, times(2)).commitTransaction()
+  }
+
+  it should "roll back when there is an issue importing one of the correspondence list snapshots" in {
+    val lastUpdated        = LocalDate.of(2025, 3, 12)
+    val lastUpdatedInstant = lastUpdated.atStartOfDay(ZoneOffset.UTC).toInstant
+
+    // Last updated date
+    when(appConfig.defaultLastUpdated).thenReturn(lastUpdated)
+
+    when(lastUpdatedRepository.fetchLastUpdated(any())).thenReturn(Future.successful(None))
+
+    when(
+      lastUpdatedRepository.setLastUpdated(
+        equalTo(clientSession),
+        any(),
+        anyLong(),
+        equalTo(fixedInstant)
+      )
+    )
+      .thenReturn(Future.unit)
+
+    // Correspondence list manipulation
+    when(
+      correspondenceListsRepository.fetchCorrespondenceKeys(equalTo(clientSession), equalTo(E200))
+    )
+      .thenReturn(Future.successful(Set.empty[(String, String)]))
+      .thenReturn(
+        Future.successful(
+          Set(
+            "27101944" -> "E430",
+            "27101944" -> "E440",
+            "27102019" -> "E430",
+            "27102019" -> "E440"
+          )
+        )
+      )
+
+    when(
+      correspondenceListsRepository.saveCorrespondenceListEntries(
+        equalTo(clientSession),
+        equalTo(E200),
+        any()
+      )
+    ).thenReturn(Future.unit)
+
+    // Correspondence list configuration
+    when(appConfig.correspondenceListConfigs).thenReturn(
+      List(
+        CorrespondenceListConfig(E200, SEED, "CnCode", "ExciseProductCode")
+      )
+    )
+
+    // DPS connector responses
+    when(
+      dpsConnector.fetchCodeListSnapshots(equalTo(E200), equalTo(lastUpdatedInstant))(using any())
+    )
+      .thenReturn(Source(List(snapshotsPage1, snapshotsPage2)))
+
+    // Instruction execution
+    when(
+      correspondenceListsRepository.executeInstructions(
+        equalTo(clientSession),
+        any[List[CorrespondenceListInstruction]]
+      )
+    )
+      .thenReturn(Future.unit)
+      .thenReturn(Future.failed(MongoError.NotAcknowledged))
+
+    correspondenceListsJob
+      .importCorrespondenceLists()
+      .failed
+      .futureValue mustBe MongoError.NotAcknowledged
+
+    verify(correspondenceListsRepository, times(2)).executeInstructions(
+      equalTo(clientSession),
+      any()
+    )
+
+    verify(correspondenceListsRepository, times(2))
+      .executeInstructions(equalTo(clientSession), any())
+
+    // There are two snapshots for E200, but the second snapshot import failed
+    verify(lastUpdatedRepository, times(1)).setLastUpdated(
+      equalTo(clientSession),
+      equalTo(E200),
+      equalTo(1L),
+      equalTo(fixedInstant)
+    )
+
+    // The (temporary) static data should have been saved
+    verify(correspondenceListsRepository, times(1)).saveCorrespondenceListEntries(
+      equalTo(clientSession),
+      equalTo(E200),
+      any()
+    )
+
+    // The first commit is the static data.
+    // The first DPS snapshot should have been committed, but the second should be rolled back.
+    val inOrder = Mockito.inOrder(clientSession)
+    inOrder.verify(clientSession, times(1)).commitTransaction()
+    inOrder.verify(clientSession, times(1)).commitTransaction()
+    inOrder.verify(clientSession, times(1)).abortTransaction()
+  }
+
+  "ImportCodeListsJob.processSnapshot" should "produce a list of instructions for a snapshot that contains only new entries" in {
+    when(
+      correspondenceListsRepository.fetchCorrespondenceKeys(equalTo(clientSession), equalTo(E200))
+    )
+      .thenReturn(Future.successful(Set.empty[(String, String)]))
+
+    val correspondenceListConfig =
+      CorrespondenceListConfig(E200, SEED, "CnCode", "ExciseProductCode")
+
+    val instructions = correspondenceListsJob
+      .processSnapshot(
+        clientSession,
+        correspondenceListConfig,
+        CodeListSnapshot.fromDpsSnapshot(correspondenceListConfig, snapshotsPage1.elements.head)
+      )
+      .futureValue
+
+    instructions.sortBy(ins => (ins.key, ins.value, ins.activeFrom)) mustBe List(
+      UpsertEntry(
+        CodeListEntry(
+          E200,
+          "27101944",
+          "E430",
+          Instant.parse("2025-01-01T00:00:00Z"),
+          None,
+          Some(Instant.parse("2024-12-30T00:00:00Z")),
+          Json.obj(
+            "actionIdentification" -> "433"
+          )
+        )
+      ),
+      UpsertEntry(
+        CodeListEntry(
+          E200,
+          "27101944",
+          "E440",
+          Instant.parse("2025-01-01T00:00:00Z"),
+          None,
+          Some(Instant.parse("2024-12-30T00:00:00Z")),
+          Json.obj(
+            "actionIdentification" -> "437"
+          )
+        )
+      ),
+      UpsertEntry(
+        CodeListEntry(
+          E200,
+          "27102019",
+          "E430",
+          Instant.parse("2013-11-15T00:00:00Z"),
+          None,
+          Some(Instant.parse("2013-11-14T00:00:00Z")),
+          Json.obj(
+            "actionIdentification" -> "432"
+          )
+        )
+      ),
+      UpsertEntry(
+        CodeListEntry(
+          E200,
+          "27102019",
+          "E440",
+          Instant.parse("2013-11-15T00:00:00Z"),
+          None,
+          Some(Instant.parse("2013-11-14T00:00:00Z")),
+          Json.obj(
+            "actionIdentification" -> "437"
+          )
+        )
+      )
+    )
+  }
+
+  it should "produce a list of instructions for a snapshot which contains invalidations and missing entries" in {
+    when(
+      correspondenceListsRepository.fetchCorrespondenceKeys(equalTo(clientSession), equalTo(E200))
+    )
+      .thenReturn(
+        Future.successful(
+          Set(
+            "27101944" -> "E430",
+            "27101944" -> "E440",
+            "27102019" -> "E430",
+            "27102019" -> "E440"
+          )
+        )
+      )
+
+    val correspondenceListConfig =
+      CorrespondenceListConfig(E200, SEED, "CnCode", "ExciseProductCode")
+
+    val instructions = correspondenceListsJob
+      .processSnapshot(
+        clientSession,
+        correspondenceListConfig,
+        CodeListSnapshot.fromDpsSnapshot(correspondenceListConfig, snapshotsPage2.elements.head)
+      )
+      .futureValue
+
+    instructions.sortBy(ins => (ins.key, ins.value, ins.activeFrom)) mustBe List(
+      InvalidateEntry(
+        CodeListEntry(
+          E200,
+          "27101944",
+          "E430",
+          Instant.parse("2025-01-02T00:00:00Z"),
+          None,
+          Some(Instant.parse("2025-01-01T00:00:00Z")),
+          Json.obj(
+            "actionIdentification" -> "2412"
+          )
+        )
+      ),
+      UpsertEntry(
+        CodeListEntry(
+          E200,
+          "27101944",
+          "E440",
+          Instant.parse("2025-01-01T00:00:00Z"),
+          None,
+          Some(Instant.parse("2024-12-30T00:00:00Z")),
+          Json.obj(
+            "actionIdentification" -> "2413"
+          )
+        )
+      ),
+      RecordMissingEntry(E200, "27102019", "E430", fixedInstant),
+      UpsertEntry(
+        CodeListEntry(
+          E200,
+          "27102019",
+          "E440",
+          Instant.parse("2013-11-15T00:00:00Z"),
+          None,
+          Some(Instant.parse("2013-11-14T00:00:00Z")),
+          Json.obj(
+            "actionIdentification" -> "437"
+          )
+        )
+      )
+    )
+  }
+
+  it should "pick the latest entry by modification date and action identification when there are duplicate entries for a given key->value mapping and activation date" in {
+    when(
+      correspondenceListsRepository.fetchCorrespondenceKeys(equalTo(clientSession), equalTo(E200))
+    )
+      .thenReturn(
+        Future.successful(
+          Set("27101966" -> "E470")
+        )
+      )
+
+    val correspondenceListConfig =
+      CorrespondenceListConfig(E200, SEED, "CnCode", "ExciseProductCode")
+
+    val instructions = correspondenceListsJob
+      .processSnapshot(
+        clientSession,
+        correspondenceListConfig,
+        CodeListSnapshot(
+          E200,
+          "CorrespondenceCnCodeExciseProduct",
+          1,
+          Set(
+            CodeListSnapshotEntry(
+              "27101966",
+              "E470",
+              Instant.parse("2023-11-02T00:00:00Z"),
+              Some(Instant.parse("2023-10-31T00:00:00Z")),
+              Some(Update),
+              Json.obj(
+                "actionIdentification" -> "1093"
+              )
+            ),
+            CodeListSnapshotEntry(
+              "27101966",
+              "E470",
+              Instant.parse("2023-11-02T00:00:00Z"),
+              Some(Instant.parse("2023-11-01T00:00:00Z")),
+              Some(Update),
+              Json.obj(
+                "actionIdentification" -> "1096"
+              )
+            ),
+            CodeListSnapshotEntry(
+              "27101966",
+              "E470",
+              Instant.parse("2023-11-02T00:00:00Z"),
+              Some(Instant.parse("2023-11-01T00:00:00Z")),
+              Some(Update),
+              Json.obj(
+                "actionIdentification" -> "1099"
+              )
+            )
+          )
+        )
+      )
+      .futureValue
+
+    instructions mustBe List(
+      UpsertEntry(
+        CodeListEntry(
+          E200,
+          "27101966",
+          "E470",
+          Instant.parse("2023-11-02T00:00:00Z"),
+          None,
+          Some(Instant.parse("2023-11-01T00:00:00Z")),
+          Json.obj(
+            "actionIdentification" -> "1099"
+          )
+        )
+      )
+    )
+  }
+}

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
@@ -256,7 +256,7 @@ class ImportCorrespondenceListsJobSpec
       equalTo(clientSession),
       equalTo(E200),
       equalTo(0L),
-      equalTo(Instant.parse("2024-12-27T00:00:00Z"))
+      equalTo(correspondenceListsJob.SeedExtractDate)
     )
 
     verify(clientSession, times(1)).commitTransaction()

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
@@ -264,7 +264,7 @@ class ImportCorrespondenceListsJobSpec
     verify(clientSession, times(1)).commitTransaction()
   }
 
-  it should "skip the import process when later data already exists" in {
+  it should "skip the import process when data has been imported before" in {
     when(lastUpdatedRepository.fetchLastUpdated(any()))
       .thenReturn(Future.successful(Some(LastUpdated(E200, 1, fixedInstant))))
 

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
@@ -241,6 +241,7 @@ class ImportCorrespondenceListsJobSpec
   "ImportCorrespondenceListsJob.importStaticData" should "import the static E200 codelist data" in {
     when(correspondenceListsRepository.saveCorrespondenceListEntries(any(), any(), any()))
       .thenReturn(Future.unit)
+    when(lastUpdatedRepository.setLastUpdated(any(), any(), any(), any())).thenReturn(Future.unit)
 
     correspondenceListsJob.importStaticData().futureValue
 
@@ -248,6 +249,14 @@ class ImportCorrespondenceListsJobSpec
       equalTo(clientSession),
       equalTo(E200),
       any()
+    )
+
+    // Last update date should be set to the date of the SEED extract
+    verify(lastUpdatedRepository, times(1)).setLastUpdated(
+      equalTo(clientSession),
+      equalTo(E200),
+      equalTo(0L),
+      equalTo(Instant.parse("2024-12-27T00:00:00Z"))
     )
 
     verify(clientSession, times(1)).commitTransaction()
@@ -284,7 +293,7 @@ class ImportCorrespondenceListsJobSpec
         equalTo(clientSession),
         any(),
         anyLong(),
-        equalTo(fixedInstant)
+        any()
       )
     )
       .thenReturn(Future.unit)
@@ -345,6 +354,22 @@ class ImportCorrespondenceListsJobSpec
     verify(correspondenceListsRepository, times(2))
       .executeInstructions(equalTo(clientSession), any())
 
+    // There is one set of static data for E200
+    verify(lastUpdatedRepository, times(1)).setLastUpdated(
+      equalTo(clientSession),
+      equalTo(E200),
+      anyLong(),
+      equalTo(correspondenceListsJob.SeedExtractDate)
+    )
+
+    // There is one set of static data for E200
+    verify(lastUpdatedRepository, times(1)).setLastUpdated(
+      equalTo(clientSession),
+      equalTo(E200),
+      anyLong(),
+      equalTo(correspondenceListsJob.SeedExtractDate)
+    )
+
     // There are two snapshots for E200
     verify(lastUpdatedRepository, times(2)).setLastUpdated(
       equalTo(clientSession),
@@ -378,7 +403,7 @@ class ImportCorrespondenceListsJobSpec
         equalTo(clientSession),
         any(),
         anyLong(),
-        equalTo(fixedInstant)
+        any()
       )
     )
       .thenReturn(Future.unit)
@@ -431,6 +456,14 @@ class ImportCorrespondenceListsJobSpec
 
     correspondenceListsJob.importCorrespondenceLists().futureValue
 
+    // There is one set of static data for E200
+    verify(lastUpdatedRepository, times(1)).setLastUpdated(
+      equalTo(clientSession),
+      equalTo(E200),
+      anyLong(),
+      equalTo(correspondenceListsJob.SeedExtractDate)
+    )
+
     // There are two snapshots for E200, but we already have snapshot 1
     verify(correspondenceListsRepository, times(1))
       .executeInstructions(equalTo(clientSession), any())
@@ -467,7 +500,7 @@ class ImportCorrespondenceListsJobSpec
         equalTo(clientSession),
         any(),
         anyLong(),
-        equalTo(fixedInstant)
+        any()
       )
     )
       .thenReturn(Future.unit)

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
@@ -569,10 +569,7 @@ class ImportCorrespondenceListsJobSpec
       .thenReturn(Future.unit)
       .thenReturn(Future.failed(MongoError.NotAcknowledged))
 
-    correspondenceListsJob
-      .importCodeLists()
-      .failed
-      .futureValue mustBe MongoError.NotAcknowledged
+    correspondenceListsJob.importCodeLists().futureValue
 
     verify(correspondenceListsRepository, times(2)).executeInstructions(
       equalTo(clientSession),

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJobSpec.scala
@@ -444,7 +444,7 @@ class ImportStandardCodeListsJobSpec
       .thenReturn(Future.unit)
       .thenReturn(Future.failed(MongoError.NotAcknowledged))
 
-    codeListsJob.importCodeLists().failed.futureValue mustBe MongoError.NotAcknowledged
+    codeListsJob.importCodeLists().futureValue
 
     verify(codeListsRepository, times(1)).executeInstructions(
       equalTo(clientSession),

--- a/test/uk/gov/hmrc/crdlcache/schedulers/JobSchedulerSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/JobSchedulerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.crdlcache.schedulers
 
 import org.mockito.ArgumentMatchers.any
@@ -38,6 +54,7 @@ class JobSchedulerSpec
     appConfig = mock[AppConfig]
 
     when(appConfig.importCodeListsSchedule).thenReturn("0 0 4 * * ? 2099")
+    when(appConfig.importCorrespondenceListsSchedule).thenReturn("0 0 4 * * ? 2099")
     when(jobFactory.newJob(any(), any())).thenReturn(_ => Thread.sleep(50))
 
     jobScheduler = new JobScheduler(lifecycle, schedulerFactory, jobFactory, appConfig)
@@ -50,8 +67,28 @@ class JobSchedulerSpec
   it should "return the status BLOCKED when the job is running" in {
     jobScheduler.startCodeListImport()
     // Trigger state should go to blocked while the job is running
-    eventually { jobScheduler.codeListImportStatus() mustBe JobStatus(TriggerState.BLOCKED) }
+    eventually {
+      jobScheduler.codeListImportStatus() mustBe JobStatus(TriggerState.BLOCKED)
+    }
     // It should return to normal once the job ends
-    eventually { jobScheduler.codeListImportStatus() mustBe JobStatus(TriggerState.NORMAL) }
+    eventually {
+      jobScheduler.codeListImportStatus() mustBe JobStatus(TriggerState.NORMAL)
+    }
+  }
+
+  "JobScheduler.correspondenceListImportStatus" should "return trigger status NORMAL when the job is not running" in {
+    jobScheduler.correspondenceListImportStatus() mustBe JobStatus(TriggerState.NORMAL)
+  }
+
+  it should "return the status BLOCKED when the job is running" in {
+    jobScheduler.startCorrespondenceListImport()
+    // Trigger state should go to blocked while the job is running
+    eventually {
+      jobScheduler.correspondenceListImportStatus() mustBe JobStatus(TriggerState.BLOCKED)
+    }
+    // It should return to normal once the job ends
+    eventually {
+      jobScheduler.correspondenceListImportStatus() mustBe JobStatus(TriggerState.NORMAL)
+    }
   }
 }

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ScheduledJobFactorySpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ScheduledJobFactorySpec.scala
@@ -29,11 +29,11 @@ class ScheduledJobFactorySpec extends AnyFlatSpec with Matchers with MockitoSuga
     val bundle    = mock[TriggerFiredBundle]
     val jobDetail = mock[JobDetail]
     when(bundle.getJobDetail).thenReturn(jobDetail)
-    when(jobDetail.getJobClass).thenReturn(classOf[ImportCodeListsJob])
+    when(jobDetail.getJobClass).thenReturn(classOf[ImportStandardCodeListsJob])
 
     val injector = mock[Injector]
-    val job      = mock[ImportCodeListsJob]
-    when(injector.instanceOf(classOf[ImportCodeListsJob])).thenReturn(job)
+    val job      = mock[ImportStandardCodeListsJob]
+    when(injector.instanceOf(classOf[ImportStandardCodeListsJob])).thenReturn(job)
 
     val scheduler = mock[Scheduler]
     val factory   = new ScheduledJobFactory(injector)


### PR DESCRIPTION
This PR adds a new repository and MongoDB collection for the E200 codelist.

This codelist holds the CN code <-> excise products correspondence list. It turns out that unlike every other list we know about, this list stores a many-to-many mapping of CN codes to excise product codes.

This means that there may be more than one entry for each `key` of a `CodeListEntry`, and the unique key of this collection is instead a composite of the `key` and `value` of each entry.

Using a separate collection means that can keep using a unique index on `key` for the other codelists.

Unfortunately, doing so entails a lot of duplication, not just in the Mongo repository code but also in the daily import jobs.

I have extracted common code into base classes in https://github.com/hmrc/crdl-cache/pull/26/commits/1c39d59b404f2f1d55d605fc35a9b216847ea1aa, but you folks will have to be the judge of whether that is better than the previous commit.