### PR TITLE
CRDL-272 Add a job status endpoint to facilitate acceptance testing

### DIFF
--- a/app/uk/gov/hmrc/crdlcache/controllers/testonly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/testonly/TestOnlyController.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.crdlcache.controllers.testonly
 
 import org.mongodb.scala.*
 import org.mongodb.scala.model.Filters
+import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.crdlcache.repositories.{CodeListsRepository, LastUpdatedRepository}
 import uk.gov.hmrc.crdlcache.schedulers.JobScheduler
@@ -38,6 +39,10 @@ class TestOnlyController @Inject() (
   def importCodeLists(): Action[AnyContent] = Action {
     jobScheduler.startCodeListImport()
     Accepted
+  }
+
+  def codeListImportStatus(): Action[AnyContent] = Action {
+    Ok(Json.toJson(jobScheduler.codeListImportStatus()))
   }
 
   def deleteCodeLists(): Action[AnyContent] = Action.async {

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
@@ -20,7 +20,7 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.stream.{ActorAttributes, DelayOverflowStrategy, Supervision}
 import org.mongodb.scala.ClientSession
-import org.quartz.{Job, JobExecutionContext}
+import org.quartz.{DisallowConcurrentExecution, Job, JobExecutionContext}
 import play.api.Logging
 import uk.gov.hmrc.crdlcache.config.{AppConfig, CodeListConfig}
 import uk.gov.hmrc.crdlcache.connectors.DpsConnector
@@ -37,6 +37,7 @@ import javax.inject.Inject
 import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext, Future}
 
+@DisallowConcurrentExecution
 class ImportCodeListsJob @Inject() (
   val mongoComponent: MongoComponent,
   val lockRepository: MongoLockRepository,

--- a/app/uk/gov/hmrc/crdlcache/schedulers/JobStatus.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/JobStatus.scala
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.crdlcache.config
+package uk.gov.hmrc.crdlcache.schedulers
 
-import com.google.inject.AbstractModule
-import org.quartz.SchedulerFactory
-import org.quartz.impl.StdSchedulerFactory
-import uk.gov.hmrc.crdlcache.schedulers.JobScheduler
+import org.quartz.Trigger.TriggerState
+import play.api.libs.json.{JsString, Json, Writes}
 
-import java.time.Clock
+case class JobStatus(status: TriggerState)
 
-class Module extends AbstractModule {
-
-  override def configure(): Unit = {
-    bind(classOf[AppConfig]).asEagerSingleton()
-    bind(classOf[Clock]).toInstance(Clock.systemUTC())
-    bind(classOf[SchedulerFactory]).toInstance(new StdSchedulerFactory())
-    bind(classOf[JobScheduler]).asEagerSingleton()
+object JobStatus {
+  given Writes[TriggerState] = {
+    case TriggerState.BLOCKED => JsString("RUNNING")
+    case TriggerState.NORMAL  => JsString("IDLE")
+    case other                => JsString(other.toString)
   }
+
+  given Writes[JobStatus] = Json.writes[JobStatus]
 }

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -13,6 +13,7 @@
 ->            /                                         prod.Routes
 ->            /                                         definition.Routes
 
+GET           /crdl-cache/test-only/codelists           uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.codeListImportStatus()
 POST          /crdl-cache/test-only/codelists           uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.importCodeLists()
 DELETE        /crdl-cache/test-only/codelists           uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteCodeLists()
 DELETE        /crdl-cache/test-only/last-updated        uk.gov.hmrc.crdlcache.controllers.testonly.TestOnlyController.deleteLastUpdated()

--- a/test/uk/gov/hmrc/crdlcache/schedulers/JobSchedulerSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/JobSchedulerSpec.scala
@@ -1,0 +1,57 @@
+package uk.gov.hmrc.crdlcache.schedulers
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.quartz.Trigger.TriggerState
+import org.quartz.impl.StdSchedulerFactory
+import org.quartz.{Job, SchedulerFactory}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.ApplicationLifecycle
+import uk.gov.hmrc.crdlcache.config.AppConfig
+
+import scala.concurrent.ExecutionContext
+
+class JobSchedulerSpec
+  extends AnyFlatSpec
+  with Matchers
+  with MockitoSugar
+  with BeforeAndAfterEach
+  with Eventually {
+  given ExecutionContext = ExecutionContext.global
+
+  private val schedulerFactory: SchedulerFactory = new StdSchedulerFactory()
+  private var lifecycle: ApplicationLifecycle    = _
+  private var jobFactory: ScheduledJobFactory    = _
+  private var appConfig: AppConfig               = _
+  private var jobScheduler: JobScheduler         = _
+
+  override def beforeEach(): Unit = {
+    // Clear down any job or schedule information
+    schedulerFactory.getScheduler.clear()
+
+    lifecycle = mock[ApplicationLifecycle]
+    jobFactory = mock[ScheduledJobFactory]
+    appConfig = mock[AppConfig]
+
+    when(appConfig.importCodeListsSchedule).thenReturn("0 0 4 * * ? 2099")
+    when(jobFactory.newJob(any(), any())).thenReturn(_ => Thread.sleep(50))
+
+    jobScheduler = new JobScheduler(lifecycle, schedulerFactory, jobFactory, appConfig)
+  }
+
+  "JobScheduler.codeListImportStatus" should "return trigger status NORMAL when the job is not running" in {
+    jobScheduler.codeListImportStatus() mustBe JobStatus(TriggerState.NORMAL)
+  }
+
+  it should "return the status BLOCKED when the job is running" in {
+    jobScheduler.startCodeListImport()
+    // Trigger state should go to blocked while the job is running
+    eventually { jobScheduler.codeListImportStatus() mustBe JobStatus(TriggerState.BLOCKED) }
+    // It should return to normal once the job ends
+    eventually { jobScheduler.codeListImportStatus() mustBe JobStatus(TriggerState.NORMAL) }
+  }
+}


### PR DESCRIPTION
This PR adds a job status import for the codelists import job.

This means that we can wait for the import job to complete during the acceptance tests, which should ensure that we see the data we are expecting every time.