### PR TITLE
CRDL-367 Implement internal-auth for the Fetch Codelist Entries and Fetch Codelist Versions endpoints

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.{scala,sbt}]
+charset = utf-8
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .*
 
+!.editorconfig
 !.gitignore
 !.scalafmt.conf
+!.scalafix.conf
 bin
 .bloop/
 .cache

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,13 @@
+OrganizeImports {
+  blankLines = Manual
+  targetDialect = Scala3
+  groupedImports = Merge
+  coalesceToWildcardImportThreshold = 5
+  groups = [
+    "*"
+    "---"
+    "re:java\\."
+    "re:javax\\."
+    "re:scala\\."
+  ]
+}

--- a/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.crdlcache.controllers
 
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.crdlcache.controllers.auth.Permissions.ReadCodeLists
 import uk.gov.hmrc.crdlcache.models.CodeListType.{CORRESPONDENCE, STANDARD}
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListEntry}
 import uk.gov.hmrc.crdlcache.repositories.{
@@ -25,6 +26,7 @@ import uk.gov.hmrc.crdlcache.repositories.{
   LastUpdatedRepository,
   StandardCodeListsRepository
 }
+import uk.gov.hmrc.internalauth.client.*
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import java.time.{Clock, Instant}
@@ -34,6 +36,7 @@ import scala.concurrent.ExecutionContext
 @Singleton()
 class CodeListsController @Inject() (
   cc: ControllerComponents,
+  auth: BackendAuthComponents,
   codeListsRepository: StandardCodeListsRepository,
   correspondenceListsRepository: CorrespondenceListsRepository,
   lastUpdatedRepository: LastUpdatedRepository,
@@ -46,35 +49,37 @@ class CodeListsController @Inject() (
     filterKeys: Option[Set[String]],
     filterProperties: Option[Map[String, JsValue]],
     activeAt: Option[Instant]
-  ): Action[AnyContent] = Action.async { _ =>
-    val codeListEntries = codeListCode.listType match {
-      case STANDARD =>
-        codeListsRepository
-          .fetchEntries(
-            codeListCode,
-            filterKeys,
-            filterProperties,
-            activeAt.getOrElse(clock.instant())
-          )
-      case CORRESPONDENCE =>
-        correspondenceListsRepository
-          .fetchEntries(
-            codeListCode,
-            filterKeys,
-            filterProperties,
-            activeAt.getOrElse(clock.instant())
-          )
-    }
-
-    codeListEntries.map { entries =>
-      Ok(Json.toJson(entries))
-    }
-  }
-
-  def fetchCodeListVersions: Action[AnyContent] = Action.async { _ =>
-    lastUpdatedRepository.fetchAllLastUpdated
-      .map { lastUpdatedEntries =>
-        Ok(Json.toJson(lastUpdatedEntries))
+  ): Action[AnyContent] =
+    auth.authorizedAction(ReadCodeLists).async { _ =>
+      val codeListEntries = codeListCode.listType match {
+        case STANDARD =>
+          codeListsRepository
+            .fetchEntries(
+              codeListCode,
+              filterKeys,
+              filterProperties,
+              activeAt.getOrElse(clock.instant())
+            )
+        case CORRESPONDENCE =>
+          correspondenceListsRepository
+            .fetchEntries(
+              codeListCode,
+              filterKeys,
+              filterProperties,
+              activeAt.getOrElse(clock.instant())
+            )
       }
-  }
+
+      codeListEntries.map { entries =>
+        Ok(Json.toJson(entries))
+      }
+    }
+
+  def fetchCodeListVersions: Action[AnyContent] =
+    auth.authorizedAction(ReadCodeLists).async { _ =>
+      lastUpdatedRepository.fetchAllLastUpdated
+        .map { lastUpdatedEntries =>
+          Ok(Json.toJson(lastUpdatedEntries))
+        }
+    }
 }

--- a/app/uk/gov/hmrc/crdlcache/controllers/auth/Permissions.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/auth/Permissions.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.controllers.auth
+
+import uk.gov.hmrc.internalauth.client.{IAAction, Predicate, Resource, ResourceLocation, ResourceType}
+
+object Permissions {
+  private val crdlCacheResource = "crdl-cache"
+
+  val ReadCodeLists = Predicate.Permission(
+    Resource(
+      ResourceType(crdlCacheResource),
+      ResourceLocation("/codelists")
+    ),
+    IAAction("READ")
+  )
+}

--- a/app/uk/gov/hmrc/crdlcache/controllers/auth/Permissions.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/auth/Permissions.scala
@@ -24,7 +24,7 @@ object Permissions {
   val ReadCodeLists = Predicate.Permission(
     Resource(
       ResourceType(crdlCacheResource),
-      ResourceLocation("/codelists")
+      ResourceLocation("/lists")
     ),
     IAAction("READ")
   )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -24,8 +24,8 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 # Play Modules
 play.modules.enabled += "uk.gov.hmrc.crdlcache.config.Module"
-
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
+play.modules.enabled += "uk.gov.hmrc.internalauth.client.modules.InternalAuthModule"
 
 # The application languages
 # ~~~~~
@@ -243,6 +243,11 @@ import-offices {
 
 microservice {
   services {
+    internal-auth {
+      host = localhost
+      port = 8470
+    }
+
     dps-api {
       host = localhost
       port = 7253

--- a/it/test/uk/gov/hmrc/crdlcache/controllers/BackendAuthStubProvider.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/controllers/BackendAuthStubProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.controllers
+
+import play.api.mvc.ControllerComponents
+import uk.gov.hmrc.internalauth.client.BackendAuthComponents
+import uk.gov.hmrc.internalauth.client.test.{BackendAuthComponentsStub, StubBehaviour}
+
+import javax.inject.{Inject, Provider}
+import scala.concurrent.ExecutionContext
+
+class BackendAuthStubProvider @Inject() (stubBehaviour: StubBehaviour)(using
+  cc: ControllerComponents,
+  ec: ExecutionContext
+) extends Provider[BackendAuthComponents] {
+  override def get(): BackendAuthComponents = BackendAuthComponentsStub(stubBehaviour)
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,22 +2,25 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.13.0"
-  private val hmrcMongoVersion = "2.6.0"
+  private val bootstrapVersion    = "9.13.0"
+  private val hmrcMongoVersion    = "2.6.0"
+  private val internalAuthVersion = "4.0.0"
+  private val playSuffix          = "play-30"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"         %% "bootstrap-backend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc.mongo"   %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
-    "org.quartz-scheduler" % "quartz"                    % "2.5.0"
+    "uk.gov.hmrc"         %% s"bootstrap-backend-$playSuffix"    % bootstrapVersion,
+    "uk.gov.hmrc"         %% s"internal-auth-client-$playSuffix" % internalAuthVersion,
+    "uk.gov.hmrc.mongo"   %% s"hmrc-mongo-$playSuffix"           % hmrcMongoVersion,
+    "org.quartz-scheduler" % "quartz"                            % "2.5.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % bootstrapVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % hmrcMongoVersion
+    "uk.gov.hmrc"       %% s"bootstrap-test-$playSuffix"  % bootstrapVersion,
+    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-test-$playSuffix" % hmrcMongoVersion
   ).map(_ % Test)
 
   val it: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "http-verbs-test-play-30" % "15.2.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % hmrcMongoVersion
+    "uk.gov.hmrc"       %% s"http-verbs-test-$playSuffix" % "15.2.0",
+    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-test-$playSuffix" % hmrcMongoVersion
   ).map(_ % Test)
 }

--- a/test/uk/gov/hmrc/crdlcache/schedulers/JobStatusSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/JobStatusSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcache.schedulers
+
+import org.quartz.Trigger.TriggerState
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.Json
+
+class JobStatusSpec extends AnyWordSpec with Matchers with Inspectors {
+  private val triggerStates = TriggerState.values()
+    .filterNot(Set(TriggerState.NORMAL, TriggerState.BLOCKED))
+
+  "JobStatus" should {
+    "serialize TriggerState.NORMAL as IDLE" in {
+      Json.toJson(JobStatus(TriggerState.NORMAL)) shouldBe Json.obj("status" -> "IDLE")
+    }
+
+    "serialize TriggerState.BLOCKED as RUNNING" in {
+      Json.toJson(JobStatus(TriggerState.BLOCKED)) shouldBe Json.obj("status" -> "RUNNING")
+    }
+
+    "serialize other statuses as their names" in forEvery(triggerStates) { state =>
+      Json.toJson(JobStatus(state)) shouldBe Json.obj("status" -> state.toString)
+    }
+  }
+}


### PR DESCRIPTION
This PR implements internal auth for the endpoints in the CodeListsController.

It does this using the [internal-auth-client](https://github.com/hmrc/internal-auth-client)'s authorizedAction.

We define a new permission for `READ` actions at the `/lists` resource location in `crdl-cache` and secure the endpoints with that permission.

For testing, we wire up the application using the `BackendAuthComponentsStub`, which enables us to stub out the responses from internal-auth. Note that we need to use a `Provider` to do this because `BackendAuthComponentsStub` takes `ControllerComponents` as one of its implicit arguments.