### PR TITLE
Additional Ingest Logging

### DIFF
--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
@@ -25,6 +25,7 @@ import play.api.Logging
 import uk.gov.hmrc.crdlcache.config.{AppConfig, ListConfig, PhaseAndDomainListConfig}
 import uk.gov.hmrc.crdlcache.connectors.DpsConnector
 import uk.gov.hmrc.crdlcache.models.{CodeListCode, CodeListSnapshot, CodeListSnapshotEntry}
+import uk.gov.hmrc.crdlcache.models.Instruction
 import uk.gov.hmrc.crdlcache.repositories.{CodeListsRepository, LastUpdatedRepository}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.lock.{LockService, MongoLockRepository}
@@ -33,6 +34,7 @@ import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
 import java.time.{Clock, ZoneOffset}
 import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext, Future}
+import java.time.Instant
 
 @DisallowConcurrentExecution
 abstract class ImportCodeListsJob[K, I](
@@ -130,7 +132,18 @@ abstract class ImportCodeListsJob[K, I](
                 )
             }
           }
-          instructions.result()
+          val result = instructions.result()
+          for {
+            codeListCount <- repository.countEntries(listConfig.code, Instant.ofEpochMilli(0))
+          } yield {
+            logger.info(s"Code list ${listConfig.code} acquired. " +
+              s"Existing for Code: $codeListCount - " +
+              s"Upsert: ${result.collect{case u: Instruction.UpsertEntry => u}.length} - " +
+              s"Invalidate: ${result.collect{case i: Instruction.InvalidateEntry => i}.length} - " +
+              s"Record Missing: ${result.collect{case r : Instruction.RecordMissingEntry => r}.length}"
+            )
+          }
+          result
         }
     }
   }

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
@@ -136,11 +136,12 @@ abstract class ImportCodeListsJob[K, I](
           for {
             codeListCount <- repository.countEntries(listConfig.code, Instant.ofEpochMilli(0))
           } yield {
-            logger.info(s"Code list ${listConfig.code} acquired. " +
-              s"Existing for Code: $codeListCount - " +
-              s"Upsert: ${result.collect{case u: Instruction.UpsertEntry => u}.length} - " +
-              s"Invalidate: ${result.collect{case i: Instruction.InvalidateEntry => i}.length} - " +
-              s"Record Missing: ${result.collect{case r : Instruction.RecordMissingEntry => r}.length}"
+            logger.info(
+              s"Code list ${listConfig.code} acquired. " +
+                s"Existing for Code: $codeListCount - " +
+                s"Upsert: ${result.collect { case u: Instruction.UpsertEntry => u }.length} - " +
+                s"Invalidate: ${result.collect { case i: Instruction.InvalidateEntry => i }.length} - " +
+                s"Record Missing: ${result.collect { case r: Instruction.RecordMissingEntry => r }.length}"
             )
           }
           result

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
@@ -208,6 +208,9 @@ class ImportCorrespondenceListsJobSpec
       appConfig
     )
 
+    when(correspondenceListsRepository.countEntries(any(), any(), any(), any()))
+      .thenReturn(Future.successful(0))
+
     // Job lock
     val mockLock = mock[Lock]
     when(lockRepository.takeLock(any(), any(), any())).thenReturn(Future.successful(Some(mockLock)))

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportPhaseAndDomainCodeListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportPhaseAndDomainCodeListsJobSpec.scala
@@ -265,6 +265,9 @@ class ImportPhaseAndDomainCodeListsJobSpec
       appConfig
     )
 
+    when(codeListsRepository.countEntries(any(), any(), any(), any()))
+      .thenReturn(Future.successful(0))
+
     // Job lock
     val mockLock = mock[Lock]
     when(lockRepository.takeLock(any(), any(), any())).thenReturn(Future.successful(Some(mockLock)))

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJobSpec.scala
@@ -181,6 +181,9 @@ class ImportStandardCodeListsJobSpec
       appConfig
     )
 
+    when(codeListsRepository.countEntries(any(), any(), any(), any()))
+      .thenReturn(Future.successful(0))
+
     // Job lock
     val mockLock = mock[Lock]
     when(lockRepository.takeLock(any(), any(), any())).thenReturn(Future.successful(Some(mockLock)))


### PR DESCRIPTION
Add additional logging around the incoming changes on a ingest - intended to aid in detecting updates in Prod

This will allow us to see how many instructions have resulted from an incoming ingest, should there be any (note the code skips this bit if there are no new snapshot versions so a lock of log equates to no change).
This can be used to identify ingests the generate changes, particularly initial ingests of new code lists in Prod where Dev and Support teams lack direct visibility of data.

This is coupled with reducing the log level the INFO for our Prod release so that these logs can be seen. This has been confirmed by program CTL in line with complience (we handle no PII in CRDL Cache) and production usage (https://docs.tax.service.gov.uk/mdtp-handbook/documentation/manage-observability-of-a-microservice/log-information-about-your-service.html#production):
https://github.com/hmrc/app-config-production/pull/28845