### PR TITLE
Suggested Customs Office filter to improve performance by DPS

### DIFF
--- a/app/uk/gov/hmrc/crdlcache/connectors/DpsConnector.scala
+++ b/app/uk/gov/hmrc/crdlcache/connectors/DpsConnector.scala
@@ -158,7 +158,8 @@ class DpsConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConfig)(us
   )(using ec: ExecutionContext): Future[CustomsOfficeListResponse] = {
     val baseQueryParams = Map(
       "$start_index" -> startIndex,
-      "$count"       -> 10
+      "$count"       -> 10,
+      "iscurrentindicator" -> 1 // Possible improvement suggested by DPS that should have their API prefilter to the latest version
     )
 
     val queryParams = baseQueryParams ++

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCustomsOfficesListJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCustomsOfficesListJob.scala
@@ -164,12 +164,12 @@ class ImportCustomsOfficesListJob @Inject() (
     )
     for {
       postIngestOfficeCount <- customsOfficeListsRepository.customsOfficesCount(
-            Instant.now(),
-            domain = Some("NCTS"),
-            phase = Some("P6")
-          )
-          _ = logger.warn(
-            s"Number of NCTS P6 Customs Offices post-ingest: ${postIngestOfficeCount}"
-          )
+        Instant.now(),
+        domain = Some("NCTS"),
+        phase = Some("P6")
+      )
+      _ = logger.warn(
+        s"Number of NCTS P6 Customs Offices post-ingest: ${postIngestOfficeCount}"
+      )
     } yield ()
 }


### PR DESCRIPTION
A suggested improvement from the DPS team.
The primary issue with the Customs Offices calls to DPS is the shear amount of time that they are taking and elements along the chain timing out.
This param is supposed to only consider the latest version of Office which, we are informed, should pre-filter a lot of Customs Offices and hopefully reduce the time loading entries from the database into memory.
Without running it in QA, we cannot observe how much of an impact that this will have but given the ongoing problems and the risk to planned releases we have decided to give it a go in QA and observe the actual change it affects.