### PR TITLE
Suggested improvements with DPS

### DIFF
--- a/app/uk/gov/hmrc/crdlcache/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/crdlcache/config/AppConfig.scala
@@ -47,6 +47,8 @@ class AppConfig @Inject() (val config: Configuration) extends ServicesConfig(con
   val defaultLastUpdated: LocalDate =
     LocalDate.parse(config.get[String]("last-updated-date.default"))
 
+  val customsOfficesPageSize = config.get[Int]("customsOfficesPageSize")
+
   private def loadListConfigs[T](configPath: String)(mapper: Config => T): List[T] = {
     val listElementName = configPath.split("import-").last
     config

--- a/app/uk/gov/hmrc/crdlcache/connectors/DpsConnector.scala
+++ b/app/uk/gov/hmrc/crdlcache/connectors/DpsConnector.scala
@@ -147,7 +147,7 @@ class DpsConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConfig)(us
         if (response.elements.isEmpty)
           None
         else
-          Some((startIndex + 10, response))
+          Some((startIndex + appConfig.customsOfficesPageSize, response))
       }
     }
 
@@ -158,7 +158,7 @@ class DpsConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConfig)(us
   )(using ec: ExecutionContext): Future[CustomsOfficeListResponse] = {
     val baseQueryParams = Map(
       "$start_index" -> startIndex,
-      "$count"       -> 10,
+      "$count"       -> appConfig.customsOfficesPageSize,
       "iscurrentindicator" -> 1 // Possible improvement suggested by DPS that should have their API prefilter to the latest version
     )
 

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCustomsOfficesListJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCustomsOfficesListJob.scala
@@ -36,7 +36,7 @@ import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
 
 import java.time.{Clock, LocalDate, ZoneOffset}
 import javax.inject.Inject
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.*
 import java.time.Instant
 
@@ -156,13 +156,11 @@ class ImportCustomsOfficesListJob @Inject() (
   def execute(
     context: JobExecutionContext
   ): Unit =
-    Await.result(
-      withLock(importCustomsOfficeLists()).map {
-        _.getOrElse { logger.info("Import Customs offices job lock could not be obtained") }
-      },
-      Duration.Inf
-    )
+    val importFuture = withLock(importCustomsOfficeLists()).map {
+      _.getOrElse { logger.info("Import Customs offices job lock could not be obtained") }
+    }
     for {
+      _ <- importFuture
       postIngestOfficeCount <- customsOfficeListsRepository.customsOfficesCount(
         Instant.now(),
         domain = Some("NCTS"),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -68,6 +68,8 @@ last-updated-date {
   default = "2025-11-01"
 }
 
+customsOfficesPageSize = 50
+
 import-codelists {
   schedule = "0 30 23 ? * Tue"
 
@@ -534,7 +536,7 @@ import-pd-lists {
   ]
 }
 
-  import-correspondence-lists {
+import-correspondence-lists {
   schedule = "0 30 23 ? * Tue"
 
   correspondence-lists = [

--- a/it/test/uk/gov/hmrc/crdlcache/connectors/DpsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/connectors/DpsConnectorSpec.scala
@@ -68,6 +68,7 @@ class DpsConnectorSpec
       "microservice.services.dps-api.clientId"             -> clientId,
       "microservice.services.dps-api.clientSecret"         -> clientSecret,
       "last-updated-date.default"                          -> "2025-05-29",
+      "customsOfficesPageSize"                             -> "10",
       "import-codelists.schedule"                          -> "* * * * * ?",
       "import-pd-lists.schedule"                           -> "* * * * * ?",
       "import-offices.schedule"                            -> "* * * * * ?",

--- a/test/uk/gov/hmrc/crdlcache/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/config/AppConfigSpec.scala
@@ -37,6 +37,7 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
         "microservice.services.dps-api.clientId"             -> "abc123",
         "microservice.services.dps-api.clientSecret"         -> "def456",
         "last-updated-date.default"                          -> "2025-11-01",
+        "customsOfficesPageSize"                             -> "50",
         "import-codelists.schedule"                          -> "*/10 * * * * ?",
         "import-pd-lists.schedule"                           -> "*/10 * * * * ?",
         "import-correspondence-lists.schedule"               -> "*/10 * * * * ?",
@@ -114,6 +115,7 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
     appConfig.importOfficesJobPhase mustBe Some("P6")
     appConfig.importOfficesJobDomain mustBe Some("NCTS")
     appConfig.defaultLastUpdated mustBe LocalDate.of(2025, 11, 1)
+    appConfig.customsOfficesPageSize mustBe 50
     appConfig.codeListConfigs mustBe List(
       CodeListConfig(BC01, SEED, "EvidenceTypeCode"),
       CodeListConfig(BC03, SEED, "AcoActionNotPossibleReasonCode"),


### PR DESCRIPTION
Some improvements to customs office lists ingestation from conversations from the DPS team.

A few things going on here:
- Up the page size for COLs to 50 by default. From the way DPS have explained how their API works, they load the same amount of data each time before filtering it so fewer calls with larger payloads is going to be more efficient. This has been made configurable so that it can be tuned per environment if need be.
 - I have tested this locally against stub data and it works fine in that there is only one page.
 - I have also tested this against the QA DPS CRDL instance it loads the data in about 6 minutes instead of 20 on my hardware so a distinct improvement. It cannot complete the job as the sheer amount of data overflows my mongo instances assigned memory but it does fetch all of the data successfully.
- The post ingest log occurs synchronously on a single local machine but appears to be asynchronous out on QA where we are getting both the pre and post logs within milliseconds of each other followed by those tracking calls for the ingest data.
 - I have tied both of these into the for comprehension to see if this improves the dependency of the completing the ingest first but this works exactly the same locally as it did before where the problem could not be replicated. It does continue to work as before though so we can be reasonably confident this won't be any worse.
 - We need to observe this out on QA and if something does go wrong, we *will need to revert* but without a way to replicate we don't have any other options at this time.