### PR TITLE
Remove log that isn't providing value

### DIFF
--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCustomsOfficesListJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCustomsOfficesListJob.scala
@@ -36,7 +36,7 @@ import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
 
 import java.time.{Clock, LocalDate, ZoneOffset}
 import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.*
 import java.time.Instant
 
@@ -156,18 +156,10 @@ class ImportCustomsOfficesListJob @Inject() (
   def execute(
     context: JobExecutionContext
   ): Unit =
-    val importFuture = withLock(importCustomsOfficeLists()).map {
-      _.getOrElse { logger.info("Import Customs offices job lock could not be obtained") }
-    }
-    for {
-      _ <- importFuture
-      postIngestOfficeCount <- customsOfficeListsRepository.customsOfficesCount(
-        Instant.now(),
-        domain = Some("NCTS"),
-        phase = Some("P6")
-      )
-      _ = logger.warn(
-        s"Number of NCTS P6 Customs Offices post-ingest: ${postIngestOfficeCount}"
-      )
-    } yield ()
+    Await.result(
+      withLock(importCustomsOfficeLists()).map {
+        _.getOrElse { logger.info("Import Customs offices job lock could not be obtained") }
+      },
+      Duration.Inf
+    )
 }


### PR DESCRIPTION
Reverting the changes we made the our post ingress log that is displaying async issues and not waiting on the job to complete.
This reverts the changes made to ImportCustomsOfficesListJob..execute in https://github.com/hmrc/crdl-cache/pull/94 and https://github.com/hmrc/crdl-cache/pull/99