### PR TITLE
CRDL Hotfix: Expand Codelist keys to include optional Phase and Domain

### DIFF
--- a/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
+++ b/app/uk/gov/hmrc/crdlcache/controllers/CodeListsController.scala
@@ -188,9 +188,11 @@ class CodeListsController @Inject() (
     }
 
   def getSnapshot(
-    code: String
+    code: String,
+    phase: Option[String] = None,
+    domain: Option[String] = None
   ): Action[AnyContent] = auth.authorizedAction(ReadCodeLists).async { _ =>
-    lastUpdatedRepository.fetchLastUpdated(CodeListCode.fromString(code)).map {
+    lastUpdatedRepository.fetchLastUpdated(CodeListCode.fromString(code), phase, domain).map {
       case Some(snapshot) => Ok(Json.toJson(snapshot))
       case None           => NotFound
     }

--- a/app/uk/gov/hmrc/crdlcache/models/CodeListKey.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/CodeListKey.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,4 @@
 
 package uk.gov.hmrc.crdlcache.models
 
-import play.api.libs.json.*
-
-import java.time.Instant
-
-case class CodeListEntry(
-  codeListCode: CodeListCode,
-  key: String,
-  value: String,
-  activeFrom: Instant,
-  activeTo: Option[Instant],
-  updatedAt: Option[Instant],
-  properties: JsObject,
-  phase: Option[String],
-  domain: Option[String]
-)
-
-object CodeListEntry {
-  def asCodeListKey(codeListEntry: CodeListEntry): CodeListKey =
-    CodeListKey(codeListEntry.key, codeListEntry.phase, codeListEntry.domain)
-}
+final case class CodeListKey(key: String, phase: Option[String], domain: Option[String])

--- a/app/uk/gov/hmrc/crdlcache/models/Instruction.scala
+++ b/app/uk/gov/hmrc/crdlcache/models/Instruction.scala
@@ -22,19 +22,25 @@ enum Instruction {
   case UpsertEntry(codeListEntry: CodeListEntry)
   case InvalidateEntry(codeListEntry: CodeListEntry)
   // case DeleteEntry(codeListEntry: CodeListEntry)
-  case RecordMissingEntry(codeListCode: CodeListCode, override val key: String, removedAt: Instant)
+  case RecordMissingEntry(
+    codeListCode: CodeListCode,
+    override val key: String,
+    phase: Option[String],
+    domain: Option[String],
+    removedAt: Instant
+  )
 
   def key: String = this match {
     case Instruction.UpsertEntry(codeListEntry)     => codeListEntry.key
     case Instruction.InvalidateEntry(codeListEntry) => codeListEntry.key
     // case Instruction.DeleteEntry(codeListEntry)     => codeListEntry.key
-    case Instruction.RecordMissingEntry(_, key, _) => key
+    case Instruction.RecordMissingEntry(_, key, _, _, _) => key
   }
 
   def activeFrom: Instant = this match {
     case Instruction.UpsertEntry(codeListEntry)     => codeListEntry.activeFrom
     case Instruction.InvalidateEntry(codeListEntry) => codeListEntry.activeFrom
     // case Instruction.DeleteEntry(codeListEntry)     => codeListEntry.activeFrom
-    case Instruction.RecordMissingEntry(_, _, removedAt) => removedAt
+    case Instruction.RecordMissingEntry(_, _, _, _, removedAt) => removedAt
   }
 }

--- a/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/CodeListsRepository.scala
@@ -51,7 +51,8 @@ abstract class CodeListsRepository[K, I](
     indexes = IndexModel(
       Indexes.ascending("activeTo"),
       IndexOptions().expireAfter(30, TimeUnit.DAYS)
-    ) +: indexes
+    ) +: indexes,
+    replaceIndexes = true
   )
   with Transactions {
 
@@ -69,9 +70,26 @@ abstract class CodeListsRepository[K, I](
         previousInstruction.flatMap(_ => executeInstruction(session, nextInstruction))
     }
 
-  def fetchEntryKeys(session: ClientSession, code: CodeListCode): Future[Set[K]] =
+  def fetchEntryKeys(
+    session: ClientSession,
+    code: CodeListCode,
+    phase: Option[String] = None,
+    domain: Option[String] = None
+  ): Future[Set[K]] =
     collection
-      .find(session, and(equal("codeListCode", code.code), equal("activeTo", null)))
+      .find(
+        session,
+        and(
+          Seq(
+            equal("codeListCode", code.code),
+            equal("activeTo", null)
+          )
+            ++ phase.fold(None)(p =>
+              Seq(equal("phase", p))
+                ++ domain.fold(None)(d => Seq(equal("domain", d)))
+            )*
+        )
+      )
       .map(keyOfEntry)
       .toFuture()
       .map(_.toSet)

--- a/app/uk/gov/hmrc/crdlcache/repositories/CustomsOfficeListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/CustomsOfficeListsRepository.scala
@@ -72,7 +72,8 @@ class CustomsOfficeListsRepository @Inject() (val mongoComponent: MongoComponent
       ),
       IndexModel(Indexes.ascending("activeTo"), IndexOptions().expireAfter(30, TimeUnit.DAYS))
     ),
-    extraCodecs = Seq(Codecs.playFormatCodec(CustomsOfficeSummary.format))
+    extraCodecs = Seq(Codecs.playFormatCodec(CustomsOfficeSummary.format)),
+    replaceIndexes = true
   )
   with Transactions
   with Logging {

--- a/app/uk/gov/hmrc/crdlcache/repositories/LastUpdatedRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/LastUpdatedRepository.scala
@@ -41,7 +41,10 @@ class LastUpdatedRepository @Inject() (val mongoComponent: MongoComponent)(using
     collectionName = "last-updated",
     domainFormat = MongoFormats.lastUpdatedFormat,
     indexes = Seq(
-      IndexModel(Indexes.ascending("codeListCode", "phase", "domain"), IndexOptions().unique(true))
+      IndexModel(Indexes.ascending("codeListCode", "phase", "domain"), IndexOptions().unique(true)),
+      IndexModel(Indexes.ascending("codeListCode"), IndexOptions().unique(false)),
+      IndexModel(Indexes.ascending("phase"), IndexOptions().unique(false)),
+      IndexModel(Indexes.ascending("domain"), IndexOptions().unique(false))
     ),
     replaceIndexes = true
   )

--- a/app/uk/gov/hmrc/crdlcache/repositories/LastUpdatedRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/LastUpdatedRepository.scala
@@ -41,18 +41,29 @@ class LastUpdatedRepository @Inject() (val mongoComponent: MongoComponent)(using
     collectionName = "last-updated",
     domainFormat = MongoFormats.lastUpdatedFormat,
     indexes = Seq(
-      IndexModel(Indexes.ascending("codeListCode"), IndexOptions().unique(true)),
-      IndexModel(Indexes.ascending("phase")),
-      IndexModel(Indexes.ascending("domain"))
-    )
+      IndexModel(Indexes.ascending("codeListCode", "phase", "domain"), IndexOptions().unique(true))
+    ),
+    replaceIndexes = true
   )
   with Transactions {
 
   // This collection contains only one document per codelist
   override lazy val requiresTtlIndex: Boolean = false
 
-  def fetchLastUpdated(codeListCode: CodeListCode): Future[Option[LastUpdated]] = {
-    collection.find(equal("codeListCode", codeListCode.code)).headOption()
+  def fetchLastUpdated(
+    codeListCode: CodeListCode,
+    phase: Option[String],
+    domain: Option[String]
+  ): Future[Option[LastUpdated]] = {
+    collection
+      .find(
+        and(
+          Seq(equal("codeListCode", codeListCode.code))
+            ++ phase.fold(None)(p => Seq(equal("phase", p)))
+            ++ domain.fold(None)(d => Seq(equal("domain", d)))*
+        )
+      )
+      .headOption()
   }
 
   def fetchAllLastUpdated: Future[Seq[LastUpdated]] = {

--- a/app/uk/gov/hmrc/crdlcache/repositories/StandardCodeListsRepository.scala
+++ b/app/uk/gov/hmrc/crdlcache/repositories/StandardCodeListsRepository.scala
@@ -24,7 +24,7 @@ import play.api.Logging
 import play.api.libs.json.*
 import uk.gov.hmrc.crdlcache.models
 import uk.gov.hmrc.crdlcache.models.Instruction.{InvalidateEntry, RecordMissingEntry, UpsertEntry}
-import uk.gov.hmrc.crdlcache.models.{CodeListEntry, Instruction}
+import uk.gov.hmrc.crdlcache.models.{CodeListEntry, CodeListKey, Instruction}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.Codecs
 
@@ -35,7 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class StandardCodeListsRepository @Inject() (mongoComponent: MongoComponent)(using
   ec: ExecutionContext
-) extends CodeListsRepository[String, Instruction](
+) extends CodeListsRepository[CodeListKey, Instruction](
     mongoComponent,
     collectionName = "codelists",
     extraCodecs =
@@ -43,7 +43,7 @@ class StandardCodeListsRepository @Inject() (mongoComponent: MongoComponent)(usi
         Codecs.playFormatSumCodecs[JsBoolean](Format(Reads.JsBooleanReads, Writes.jsValueWrites)),
     indexes = Seq(
       IndexModel(
-        Indexes.ascending("codeListCode", "key", "activeFrom"),
+        Indexes.ascending("codeListCode", "phase", "domain", "key", "activeFrom"),
         IndexOptions().unique(true)
       ),
       IndexModel(
@@ -60,9 +60,13 @@ class StandardCodeListsRepository @Inject() (mongoComponent: MongoComponent)(usi
 
   override def activationDate(instruction: Instruction): Instant = instruction.activeFrom
 
-  override def keyOfEntry(codeListEntry: CodeListEntry): String = codeListEntry.key
+  override def keyOfEntry(codeListEntry: CodeListEntry): CodeListKey =
+    CodeListKey(codeListEntry.key, codeListEntry.phase, codeListEntry.domain)
 
-  override def filtersForKey(key: String): Seq[Bson] = Seq(equal("key", key))
+  override def filtersForKey(key: CodeListKey): Seq[Bson] =
+    Seq(equal("key", key.key))
+      ++ key.phase.fold(None)(p => Seq(equal("phase", p)))
+      ++ key.domain.fold(None)(d => Seq(equal("domain", d)))
 
   def executeInstruction(session: ClientSession, instruction: Instruction): Future[Unit] =
     instruction match {
@@ -74,7 +78,7 @@ class StandardCodeListsRepository @Inject() (mongoComponent: MongoComponent)(usi
           _ <- supersedePreviousEntries(
             session,
             codeListEntry.codeListCode,
-            codeListEntry.key,
+            CodeListEntry.asCodeListKey(codeListEntry),
             codeListEntry.activeFrom,
             includeActiveFrom = false
           )
@@ -87,16 +91,16 @@ class StandardCodeListsRepository @Inject() (mongoComponent: MongoComponent)(usi
         supersedePreviousEntries(
           session,
           codeListEntry.codeListCode,
-          codeListEntry.key,
+          CodeListEntry.asCodeListKey(codeListEntry),
           codeListEntry.activeFrom,
           includeActiveFrom = true
         )
-      case RecordMissingEntry(codeListCode, key, removedAt) =>
+      case RecordMissingEntry(codeListCode, key, phase, domain, removedAt) =>
         logger.debug(s"Recording removal of entry in codelist ${codeListCode.code} with key $key")
         supersedePreviousEntries(
           session,
           codeListCode,
-          key,
+          CodeListKey(key, phase, domain),
           removedAt,
           includeActiveFrom = true
         )

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportCodeListsJob.scala
@@ -81,79 +81,96 @@ abstract class ImportCodeListsJob[K, I](
           "Both phase and domain must be provided together, or neither should be provided"
         )
       case _ =>
-        repository.fetchEntryKeys(session, listConfig.code).map { currentKeySet =>
-          val incomingKeySet = newSnapshot.entries.map(keyOfEntry)
-          val mergedKeySet   = currentKeySet.union(incomingKeySet)
+        repository.fetchEntryKeys(session, listConfig.code, phase, domain).map { currentKeySet =>
+          {
+            val incomingKeySet =
+              newSnapshot.entries.map(_.copy(phase = phase, domain = domain)).map(keyOfEntry)
+            val mergedKeySet = currentKeySet.union(incomingKeySet)
 
-          val groupedEntries = newSnapshot.entries.toList.groupBy(keyOfEntry)
+            val groupedEntries = newSnapshot.entries.toList
+              .map(_.copy(phase = phase, domain = domain))
+              .groupBy(keyOfEntry)
 
-          val instructions = List.newBuilder[I]
+            val instructions = List.newBuilder[I]
 
-          for (key <- mergedKeySet) {
-            val hasExistingEntry = currentKeySet.contains(key)
-            val maybeNewEntries  = groupedEntries.get(key)
+            for (key <- mergedKeySet) {
+              val hasExistingEntry = currentKeySet.contains(key)
+              val maybeNewEntries  = groupedEntries.get(key)
 
-            // In case of multiple entries for a given key with the same activation date,
-            // the one with the latest modification timestamp and latest action ID is used.
-            val entriesByDate = maybeNewEntries.map { newEntries =>
-              newEntries
-                .groupBy(_.activeFrom) // Group by activation date
-                .view
-                .mapValues(
-                  _.maxBy(entry =>
-                    (
-                      entry.updatedAt,
-                      entry.properties.value.get("actionIdentification").flatMap(_.asOpt[String])
+              // In case of multiple entries for a given key with the same activation date,
+              // the one with the latest modification timestamp and latest action ID is used.
+              val entriesByDate = maybeNewEntries.map { newEntries =>
+                newEntries
+                  .groupBy(_.activeFrom) // Group by activation date
+                  .view
+                  .mapValues(
+                    _.maxBy(entry =>
+                      (
+                        entry.updatedAt,
+                        entry.properties.value.get("actionIdentification").flatMap(_.asOpt[String])
+                      )
                     )
+                  ) // Pick the latest modification and SEED "ActionIdentification"
+                  .values
+                  .toSet
+              }
+
+              (hasExistingEntry, entriesByDate) match {
+                case (_, Some(newEntries)) =>
+                  val pDEntries = (phase, domain) match {
+                    case (Some(phase), Some(domain)) =>
+                      newEntries.map(_.copy(phase = Some(phase), domain = Some(domain)))
+                    case _ =>
+                      newEntries
+                  }
+                  instructions ++= pDEntries.map(
+                    processEntry(listConfig.code, _)
                   )
-                ) // Pick the latest modification and SEED "ActionIdentification"
-                .values
-                .toSet
+
+                case (true, None) =>
+                  instructions += recordMissing(listConfig.code, key)
+
+                case _ =>
+                  throw IllegalStateException(
+                    "Impossible case - we have neither a new nor existing entry for a key"
+                  )
+              }
             }
-
-            (hasExistingEntry, entriesByDate) match {
-              case (_, Some(newEntries)) =>
-                val pDEntries = (phase, domain) match {
-                  case (Some(phase), Some(domain)) =>
-                    newEntries.map(_.copy(phase = Some(phase), domain = Some(domain)))
-                  case _ =>
-                    newEntries
-                }
-                instructions ++= pDEntries.map(
-                  processEntry(listConfig.code, _)
-                )
-
-              case (true, None) =>
-                instructions += recordMissing(listConfig.code, key)
-
-              case _ =>
-                throw IllegalStateException(
-                  "Impossible case - we have neither a new nor existing entry for a key"
-                )
+            val result = instructions.result()
+            for {
+              codeListCount <- repository.countEntries(listConfig.code, Instant.now())
+            } yield {
+              logger.warn(
+                s"Code list ${listConfig.code} acquired. " +
+                  s"Existing for Code: $codeListCount - " +
+                  s"Upsert: ${result.collect { case u: Instruction.UpsertEntry => u }.length} - " +
+                  s"Invalidate: ${result.collect { case i: Instruction.InvalidateEntry => i }.length} - " +
+                  s"Record Missing: ${result.collect { case r: Instruction.RecordMissingEntry => r }.length}"
+              )
             }
+            result
           }
-          val result = instructions.result()
-          for {
-            codeListCount <- repository.countEntries(listConfig.code, Instant.now())
-          } yield {
-            logger.warn(
-              s"Code list ${listConfig.code} acquired. " +
-                s"Existing for Code: $codeListCount - " +
-                s"Upsert: ${result.collect { case u: Instruction.UpsertEntry => u }.length} - " +
-                s"Invalidate: ${result.collect { case i: Instruction.InvalidateEntry => i }.length} - " +
-                s"Record Missing: ${result.collect { case r: Instruction.RecordMissingEntry => r }.length}"
-            )
-          }
-          result
         }
     }
   }
 
   protected def importCodeList(codeListConfig: ListConfig): Future[Unit] = {
+    val phase = codeListConfig match {
+      case c: PhaseAndDomainListConfig => Some(c.phase)
+      case _                           => None
+    }
+    val domain = codeListConfig match {
+      case c: PhaseAndDomainListConfig => Some(c.domain)
+      case _                           => None
+    }
     for {
       // Fetch last updated timestamp
       preIngestCodeListCount <- repository.countEntries(codeListConfig.code, Instant.now())
-      storedLastUpdated      <- lastUpdatedRepository.fetchLastUpdated(codeListConfig.code)
+      storedLastUpdated <- lastUpdatedRepository.fetchLastUpdated(
+        codeListConfig.code,
+        phase,
+        domain
+      )
       defaultLastUpdated = appConfig.defaultLastUpdated.atStartOfDay(ZoneOffset.UTC).toInstant
       lastUpdated        = storedLastUpdated.map(_.lastUpdated).getOrElse(defaultLastUpdated)
 
@@ -173,7 +190,9 @@ abstract class ImportCodeListsJob[K, I](
         .mapConcat(_.elements)
         .dropWhile { snapshot =>
           // Ignore snapshot versions that we already have
-          storedLastUpdated.exists(_.snapshotVersion >= snapshot.snapshotversion)
+          storedLastUpdated.exists(s =>
+            s.snapshotVersion >= snapshot.snapshotversion && s.phase == phase && s.domain == domain
+          )
         }
         .map(CodeListSnapshot.fromDpsSnapshot(codeListConfig, _))
         .mapAsync(1) { snapshot =>

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportPhaseAndDomainCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportPhaseAndDomainCodeListsJob.scala
@@ -39,7 +39,7 @@ class ImportPhaseAndDomainCodeListsJob @Inject() (
   appConfig: AppConfig,
   clock: Clock
 )(using system: ActorSystem, ec: ExecutionContext)
-  extends ImportCodeListsJob[String, Instruction](
+  extends ImportCodeListsJob[CodeListKey, Instruction](
     "import-pd-lists",
     mongoComponent,
     lockRepository,
@@ -53,14 +53,23 @@ class ImportPhaseAndDomainCodeListsJob @Inject() (
   override protected def listConfigs: List[ListConfig] =
     appConfig.phaseAndDomainListConfigs
 
-  override protected def keyOfEntry(snapshotEntry: CodeListSnapshotEntry): String =
-    snapshotEntry.key
+  override protected def keyOfEntry(snapshotEntry: CodeListSnapshotEntry): CodeListKey =
+    CodeListKey(snapshotEntry.key, snapshotEntry.phase, snapshotEntry.domain)
 
-  override protected def recordMissing(codeListCode: CodeListCode, key: String): Instruction = {
+  override protected def recordMissing(
+    codeListCode: CodeListCode,
+    key: CodeListKey
+  ): Instruction = {
     // DPS provides no snapshot dates:
     // the best we can do with removed entries is to use the start of today as their deactivation date
     val startOfToday = LocalDate.now(clock).atStartOfDay(ZoneOffset.UTC)
-    RecordMissingEntry(codeListCode, key, removedAt = startOfToday.toInstant)
+    RecordMissingEntry(
+      codeListCode,
+      key.key,
+      key.phase,
+      key.domain,
+      removedAt = startOfToday.toInstant
+    )
   }
 
   override def processEntry(

--- a/app/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJob.scala
+++ b/app/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJob.scala
@@ -39,7 +39,7 @@ class ImportStandardCodeListsJob @Inject() (
   appConfig: AppConfig,
   clock: Clock
 )(using system: ActorSystem, ec: ExecutionContext)
-  extends ImportCodeListsJob[String, Instruction](
+  extends ImportCodeListsJob[CodeListKey, Instruction](
     "import-code-lists",
     mongoComponent,
     lockRepository,
@@ -53,14 +53,23 @@ class ImportStandardCodeListsJob @Inject() (
   override protected def listConfigs: List[ListConfig] =
     appConfig.codeListConfigs
 
-  override protected def keyOfEntry(snapshotEntry: CodeListSnapshotEntry): String =
-    snapshotEntry.key
+  override def keyOfEntry(codeListEntry: CodeListSnapshotEntry): CodeListKey =
+    CodeListKey(codeListEntry.key, codeListEntry.phase, codeListEntry.domain)
 
-  override protected def recordMissing(codeListCode: CodeListCode, key: String): Instruction = {
+  override protected def recordMissing(
+    codeListCode: CodeListCode,
+    key: CodeListKey
+  ): Instruction = {
     // DPS provides no snapshot dates:
     // the best we can do with removed entries is to use the start of today as their deactivation date
     val startOfToday = LocalDate.now(clock).atStartOfDay(ZoneOffset.UTC)
-    RecordMissingEntry(codeListCode, key, removedAt = startOfToday.toInstant)
+    RecordMissingEntry(
+      codeListCode,
+      key.key,
+      key.phase,
+      key.domain,
+      removedAt = startOfToday.toInstant
+    )
   }
 
   override def processEntry(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -10,4 +10,4 @@ GET     /admin/offices/summaries            uk.gov.hmrc.crdlcache.controllers.Cu
 GET     /admin/offices/:referenceNumber     uk.gov.hmrc.crdlcache.controllers.CustomsOfficeListsController.fetchCustomsOfficeDetail(referenceNumber: String, activeAt: Option[Instant])
 GET     /admin/lists                        uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListVersionsPaged(pageNum: Int, pageSize: Int, codeListCode: Option[String], phase: Option[String], domain: Option[String])
 GET     /admin/lists/:code/entries          uk.gov.hmrc.crdlcache.controllers.CodeListsController.fetchCodeListEntriesPaginated(code: CodeListCode, pageNum: Int, pageSize: Int, activeAt: Option[Instant], key: Option[String], value: Option[String])
-GET     /admin/snapshot/:code               uk.gov.hmrc.crdlcache.controllers.CodeListsController.getSnapshot(code: String)
+GET     /admin/snapshot/:code               uk.gov.hmrc.crdlcache.controllers.CodeListsController.getSnapshot(code: String, phase: Option[String] ?= None, domain: Option[String] ?= None)

--- a/it/test/uk/gov/hmrc/crdlcache/controllers/CodeListsControllerSpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/controllers/CodeListsControllerSpec.scala
@@ -1359,7 +1359,7 @@ class CodeListsControllerSpec
   "CodeListsController.getSnapShot" should "return 200 OK with a paged result when no filters are provided" in {
     when(authStub.stubAuth(equalTo(Some(ReadCodeLists)), equalTo(Retrieval.EmptyRetrieval)))
       .thenReturn(Future.unit)
-    when(lastUpdatedRepository.fetchLastUpdated(equalTo(BC08)))
+    when(lastUpdatedRepository.fetchLastUpdated(equalTo(BC08), equalTo(None), equalTo(None)))
       .thenReturn(Future.successful(Some(LastUpdated(BC08, 1, None, None, Instant.parse("2025-06-29T00:00:00Z")))))
 
     val response = httpClientV2
@@ -1375,7 +1375,7 @@ class CodeListsControllerSpec
   "CodeListsController.getSnapShot" should "return 404 Not Found when no snapshot is found" in {
     when(authStub.stubAuth(equalTo(Some(ReadCodeLists)), equalTo(Retrieval.EmptyRetrieval)))
       .thenReturn(Future.unit)
-    when(lastUpdatedRepository.fetchLastUpdated(equalTo(BC08)))
+    when(lastUpdatedRepository.fetchLastUpdated(equalTo(BC08), equalTo(None), equalTo(None)))
       .thenReturn(Future.successful(None))
 
     val response = httpClientV2

--- a/it/test/uk/gov/hmrc/crdlcache/repositories/LastUpdatedRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/repositories/LastUpdatedRepositorySpec.scala
@@ -59,7 +59,7 @@ class LastUpdatedRepositorySpec
     repository.withClientSession(test).futureValue
 
   "LastUpdatedRepository.fetchLastUpdated" should "return None when no last updated date has been populated" in {
-    repository.fetchLastUpdated(BC08).futureValue mustBe None
+    repository.fetchLastUpdated(BC08, None, None).futureValue mustBe None
   }
 
   "LastUpdatedRepository.setLastUpdated" should "upsert the last updated date when it is not present" in withSession {
@@ -67,7 +67,7 @@ class LastUpdatedRepositorySpec
       val inputInstant = clock.instant()
       for {
         _           <- repository.setLastUpdated(session, BC08, 1, None, None, inputInstant)
-        lastUpdated <- repository.fetchLastUpdated(BC08)
+        lastUpdated <- repository.fetchLastUpdated(BC08, None, None)
       } yield lastUpdated mustBe Some(LastUpdated(BC08, 1, None, None, inputInstant))
   }
 
@@ -76,7 +76,7 @@ class LastUpdatedRepositorySpec
       val inputInstant = clock.instant()
       for {
         _           <- repository.setLastUpdated(session, CL251, 1, Some("P6"), Some("NCTS"), inputInstant)
-        lastUpdated <- repository.fetchLastUpdated(CL251)
+        lastUpdated <- repository.fetchLastUpdated(CL251, None, None)
       } yield lastUpdated mustBe Some(LastUpdated(CL251, 1, Some("P6"), Some("NCTS"), inputInstant))
   }
 
@@ -84,7 +84,7 @@ class LastUpdatedRepositorySpec
     val inputInstant = clock.instant()
     for {
       _           <- repository.setLastUpdated(session, BC08, 1, None, None, inputInstant)
-      lastUpdated <- repository.fetchLastUpdated(BC66)
+      lastUpdated <- repository.fetchLastUpdated(BC66, None, None)
     } yield lastUpdated mustBe None
   }
 
@@ -94,7 +94,7 @@ class LastUpdatedRepositorySpec
     for {
       _           <- repository.setLastUpdated(session, BC08, 1, None, None, instant1)
       _           <- repository.setLastUpdated(session, BC08, 2, None, None, instant2)
-      lastUpdated <- repository.fetchLastUpdated(BC08)
+      lastUpdated <- repository.fetchLastUpdated(BC08, None, None)
     } yield lastUpdated mustBe Some(LastUpdated(BC08, 2, None, None, instant2))
   }
 
@@ -104,8 +104,8 @@ class LastUpdatedRepositorySpec
     for {
       _            <- repository.setLastUpdated(session, BC08, 1, None, None, instant1)
       _            <- repository.setLastUpdated(session, BC66, 1, None, None, instant2)
-      lastUpdated1 <- repository.fetchLastUpdated(BC08)
-      lastUpdated2 <- repository.fetchLastUpdated(BC66)
+      lastUpdated1 <- repository.fetchLastUpdated(BC08, None, None)
+      lastUpdated2 <- repository.fetchLastUpdated(BC66, None, None)
     } yield {
       lastUpdated1 mustBe Some(LastUpdated(BC08, 1, None, None, instant1))
       lastUpdated2 mustBe Some(LastUpdated(BC66, 1, None, None, instant2))

--- a/it/test/uk/gov/hmrc/crdlcache/repositories/StandardCodeListsRepositorySpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcache/repositories/StandardCodeListsRepositorySpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.{Assertion, OptionValues}
 import play.api.libs.json.{JsNull, JsString, JsTrue, Json}
 import uk.gov.hmrc.crdlcache.models.CodeListCode.{BC08, BC36, BC66}
-import uk.gov.hmrc.crdlcache.models.CodeListEntry
+import uk.gov.hmrc.crdlcache.models.{CodeListEntry, CodeListKey}
 import uk.gov.hmrc.crdlcache.models.Instruction.{InvalidateEntry, RecordMissingEntry, UpsertEntry}
 import uk.gov.hmrc.mongo.test.{
   CleanMongoCollectionSupport,
@@ -310,7 +310,7 @@ class StandardCodeListsRepositorySpec
   "StandardCodeListsRepository.fetchEntryKeys" should "return entries that have not been superseded" in withCodeListEntries(
     codelistEntries
   ) { session =>
-    repository.fetchEntryKeys(session, BC08).map(_ must contain("BL"))
+    repository.fetchEntryKeys(session, BC08).map(_ must contain(CodeListKey("BL", None, None)))
   }
 
   it should "not return entries that are invalidated" in withCodeListEntries(codelistEntries) {
@@ -329,7 +329,7 @@ class StandardCodeListsRepositorySpec
         .fetchEntryKeys(session, BC08)
         .map {
           _ mustBe entriesWithNoEndDate
-            .map(_.key)
+            .map(entry => CodeListKey(entry.key, None, None))
             .toSet
         }
   }
@@ -753,7 +753,7 @@ class StandardCodeListsRepositorySpec
         .executeInstructions(
           session,
           List(
-            RecordMissingEntry(BC08, "IO", Instant.parse("2025-05-22T00:00:00Z"))
+            RecordMissingEntry(BC08, "IO", None, None, Instant.parse("2025-05-22T00:00:00Z"))
           )
         )
 
@@ -780,7 +780,7 @@ class StandardCodeListsRepositorySpec
         .executeInstructions(
           session,
           List(
-            RecordMissingEntry(BC08, "IO", activeIoEntry.activeFrom)
+            RecordMissingEntry(BC08, "IO", None, None, activeIoEntry.activeFrom)
           )
         )
 
@@ -889,7 +889,7 @@ class StandardCodeListsRepositorySpec
                 activeIoEntry.copy(activeFrom = Instant.parse("2025-05-22T00:00:00Z"))
               ),
               UpsertEntry(updatedCzechEntry),
-              RecordMissingEntry(BC08, "CZ", Instant.parse("2025-01-17T00:00:00Z")),
+              RecordMissingEntry(BC08, "CZ", None, None, Instant.parse("2025-01-17T00:00:00Z")),
               UpsertEntry(existingCzechEntry),
               UpsertEntry(activeIoEntry)
             )

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportCorrespondenceListsJobSpec.scala
@@ -233,7 +233,8 @@ class ImportCorrespondenceListsJobSpec
     // Last updated date
     when(appConfig.defaultLastUpdated).thenReturn(lastUpdated)
 
-    when(lastUpdatedRepository.fetchLastUpdated(any())).thenReturn(Future.successful(None))
+    when(lastUpdatedRepository.fetchLastUpdated(any(), any(), any()))
+      .thenReturn(Future.successful(None))
 
     when(
       lastUpdatedRepository.setLastUpdated(
@@ -249,7 +250,12 @@ class ImportCorrespondenceListsJobSpec
 
     // Correspondence list manipulation
     when(
-      correspondenceListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(E200))
+      correspondenceListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(E200),
+        equalTo(None),
+        equalTo(None)
+      )
     )
       .thenReturn(Future.successful(Set.empty[(String, String)]))
       .thenReturn(
@@ -323,7 +329,7 @@ class ImportCorrespondenceListsJobSpec
 
     when(appConfig.defaultLastUpdated).thenReturn(LocalDate.of(2025, 3, 12))
 
-    when(lastUpdatedRepository.fetchLastUpdated(E200))
+    when(lastUpdatedRepository.fetchLastUpdated(E200, None, None))
       .thenReturn(Future.successful(Some(LastUpdated(E200, 1, None, None, storedInstant))))
 
     when(
@@ -340,7 +346,12 @@ class ImportCorrespondenceListsJobSpec
 
     // Correspondence list manipulation
     when(
-      correspondenceListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(E200))
+      correspondenceListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(E200),
+        equalTo(None),
+        equalTo(None)
+      )
     )
       .thenReturn(Future.successful(Set.empty[(String, String)]))
       .thenReturn(
@@ -434,7 +445,8 @@ class ImportCorrespondenceListsJobSpec
     // Last updated date
     when(appConfig.defaultLastUpdated).thenReturn(lastUpdated)
 
-    when(lastUpdatedRepository.fetchLastUpdated(any())).thenReturn(Future.successful(None))
+    when(lastUpdatedRepository.fetchLastUpdated(any(), any(), any()))
+      .thenReturn(Future.successful(None))
 
     when(
       lastUpdatedRepository.setLastUpdated(
@@ -450,7 +462,12 @@ class ImportCorrespondenceListsJobSpec
 
     // Correspondence list manipulation
     when(
-      correspondenceListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(E200))
+      correspondenceListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(E200),
+        equalTo(None),
+        equalTo(None)
+      )
     )
       .thenReturn(Future.successful(Set.empty[(String, String)]))
       .thenReturn(
@@ -523,7 +540,12 @@ class ImportCorrespondenceListsJobSpec
 
   "ImportCodeListsJob.processSnapshot" should "produce a list of instructions for a snapshot that contains only new entries" in {
     when(
-      correspondenceListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(E200))
+      correspondenceListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(E200),
+        equalTo(None),
+        equalTo(None)
+      )
     )
       .thenReturn(Future.successful(Set.empty[(String, String)]))
 
@@ -604,7 +626,12 @@ class ImportCorrespondenceListsJobSpec
 
   it should "produce a list of instructions for a snapshot which contains invalidations and missing entries" in {
     when(
-      correspondenceListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(E200))
+      correspondenceListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(E200),
+        equalTo(None),
+        equalTo(None)
+      )
     )
       .thenReturn(
         Future.successful(
@@ -680,7 +707,12 @@ class ImportCorrespondenceListsJobSpec
 
   it should "pick the latest entry by modification date and action identification when there are duplicate entries for a given key->value mapping and activation date" in {
     when(
-      correspondenceListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(E200))
+      correspondenceListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(E200),
+        equalTo(None),
+        equalTo(None)
+      )
     )
       .thenReturn(
         Future.successful(

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportPhaseAndDomainCodeListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportPhaseAndDomainCodeListsJobSpec.scala
@@ -291,7 +291,8 @@ class ImportPhaseAndDomainCodeListsJobSpec
     // Last updated date
     when(appConfig.defaultLastUpdated).thenReturn(lastUpdated)
 
-    when(lastUpdatedRepository.fetchLastUpdated(any())).thenReturn(Future.successful(None))
+    when(lastUpdatedRepository.fetchLastUpdated(any(), any(), any()))
+      .thenReturn(Future.successful(None))
 
     when(
       lastUpdatedRepository.setLastUpdated(
@@ -306,9 +307,23 @@ class ImportPhaseAndDomainCodeListsJobSpec
       .thenReturn(Future.unit)
 
     // Codelist manipulation
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(CL231)))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(CL231),
+        equalTo(Some("P6")),
+        equalTo(Some("NCTS"))
+      )
+    )
       .thenReturn(Future.successful(Set.empty[String]))
-      .thenReturn(Future.successful(Set("T2", "T2F")))
+      .thenReturn(
+        Future.successful(
+          Set(
+            CodeListKey("T2", Some("P6"), Some("NCTS")),
+            CodeListKey("T2F", Some("P6"), Some("NCTS"))
+          )
+        )
+      )
 
     when(codeListsRepository.countEntries(any(), any(), any(), any()))
       .thenReturn(Future.successful(0L))
@@ -422,12 +437,12 @@ class ImportPhaseAndDomainCodeListsJobSpec
 
     when(appConfig.defaultLastUpdated).thenReturn(LocalDate.of(2025, 3, 12))
 
-    when(lastUpdatedRepository.fetchLastUpdated(CL231))
+    when(lastUpdatedRepository.fetchLastUpdated(CL231, Some("P6"), Some("NCTS")))
       .thenReturn(
         Future.successful(Some(LastUpdated(CL231, 1, Some("P6"), Some("NCTS"), storedInstant)))
       )
 
-    when(lastUpdatedRepository.fetchLastUpdated(CL234))
+    when(lastUpdatedRepository.fetchLastUpdated(CL234, Some("P6"), Some("NCTS")))
       .thenReturn(
         Future.successful(Some(LastUpdated(CL234, 1, Some("P6"), Some("NCTS"), storedInstant)))
       )
@@ -445,9 +460,23 @@ class ImportPhaseAndDomainCodeListsJobSpec
       .thenReturn(Future.unit)
 
     // Codelist manipulation
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(CL231)))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(CL231),
+        equalTo(Some("P6")),
+        equalTo(Some("NCTS"))
+      )
+    )
       .thenReturn(Future.successful(Set.empty[String]))
-      .thenReturn(Future.successful(Set("T2", "T2F")))
+      .thenReturn(
+        Future.successful(
+          Set(
+            CodeListKey("T2", Some("P6"), Some("NCTS")),
+            CodeListKey("T2F", Some("P6"), Some("NCTS"))
+          )
+        )
+      )
 
     // Codelist configuration
     when(appConfig.phaseAndDomainListConfigs).thenReturn(
@@ -492,7 +521,8 @@ class ImportPhaseAndDomainCodeListsJobSpec
     // Last updated date
     when(appConfig.defaultLastUpdated).thenReturn(lastUpdated)
 
-    when(lastUpdatedRepository.fetchLastUpdated(any())).thenReturn(Future.successful(None))
+    when(lastUpdatedRepository.fetchLastUpdated(any(), any(), any()))
+      .thenReturn(Future.successful(None))
 
     when(
       lastUpdatedRepository.setLastUpdated(
@@ -507,9 +537,23 @@ class ImportPhaseAndDomainCodeListsJobSpec
       .thenReturn(Future.unit)
 
     // Codelist manipulation
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(CL231)))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(CL231),
+        equalTo(Some("P6")),
+        equalTo(Some("NCTS"))
+      )
+    )
       .thenReturn(Future.successful(Set.empty[String]))
-      .thenReturn(Future.successful(Set("T2", "T2F")))
+      .thenReturn(
+        Future.successful(
+          Set(
+            CodeListKey("T2", Some("P6"), Some("NCTS")),
+            CodeListKey("T2F", Some("P6"), Some("NCTS"))
+          )
+        )
+      )
 
     when(codeListsRepository.countEntries(any(), any(), any(), any()))
       .thenReturn(Future.successful(0L))
@@ -655,8 +699,16 @@ class ImportPhaseAndDomainCodeListsJobSpec
   }
 
   "ImportPhaseAndDomainCodeListsJob.processSnapshot" should "produce a list of instructions for a snapshot that contains only new entries" in {
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(CL231)))
-      .thenReturn(Future.successful(Set.empty[String]))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(CL231),
+        equalTo(Some("P6")),
+        equalTo(Some("NCTS"))
+      )
+    )
+      // .thenReturn(Future.successful(Set(CodeListKey("T", Some("P6"), Some("NCTS")))))
+      .thenReturn(Future.successful(Set.empty[CodeListKey]))
 
     val codeListConfig = PhaseAndDomainListConfig(CL231, CSRD2, "DeclarationTypeCode", "P6", "NCTS")
 
@@ -709,8 +761,23 @@ class ImportPhaseAndDomainCodeListsJobSpec
   }
 
   it should "produce a list of instructions for a snapshot which contains invalidations and missing entries" in {
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(CL231)))
-      .thenReturn(Future.successful(Set("T2F", "T")))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(CL231),
+        equalTo(Some("P6")),
+        equalTo(Some("NCTS"))
+      )
+    )
+      .thenReturn(
+        Future.successful(
+          Set(
+            CodeListKey("T", Some("P6"), Some("NCTS")),
+            CodeListKey("T2", Some("P6"), Some("NCTS")),
+            CodeListKey("T2F", Some("P6"), Some("NCTS"))
+          )
+        )
+      )
 
     val codeListConfig = PhaseAndDomainListConfig(CL231, CSRD2, "DeclarationTypeCode", "P6", "NCTS")
 
@@ -726,7 +793,13 @@ class ImportPhaseAndDomainCodeListsJobSpec
       .futureValue
 
     instructions.sortBy(ins => (ins.key, ins.activeFrom)) mustBe List(
-      RecordMissingEntry(CL231, "T", Instant.parse("2025-06-03T00:00:00Z")),
+      RecordMissingEntry(
+        CL231,
+        "T",
+        Some("P6"),
+        Some("NCTS"),
+        Instant.parse("2025-06-03T00:00:00Z")
+      ),
       UpsertEntry(
         CodeListEntry(
           CL231,
@@ -799,8 +872,15 @@ class ImportPhaseAndDomainCodeListsJobSpec
   }
 
   it should "pick the latest entry by modification date and action identification when there are duplicate entries for a given key and activation date" in {
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(CL234)))
-      .thenReturn(Future.successful(Set("E470")))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(CL234),
+        equalTo(Some("P6")),
+        equalTo(Some("NCTS"))
+      )
+    )
+      .thenReturn(Future.successful(Set(CodeListKey("E470", Some("P6"), Some("NCTS")))))
 
     val codeListConfig = PhaseAndDomainListConfig(CL234, CSRD2, "DocumentTypeExcise", "P6", "NCTS")
 
@@ -850,7 +930,9 @@ class ImportPhaseAndDomainCodeListsJobSpec
               Some("NCTS")
             )
           )
-        )
+        ),
+        Some("P6"),
+        Some("NCTS")
       )
       .futureValue
 

--- a/test/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJobSpec.scala
+++ b/test/uk/gov/hmrc/crdlcache/schedulers/ImportStandardCodeListsJobSpec.scala
@@ -206,7 +206,8 @@ class ImportStandardCodeListsJobSpec
     // Last updated date
     when(appConfig.defaultLastUpdated).thenReturn(lastUpdated)
 
-    when(lastUpdatedRepository.fetchLastUpdated(any())).thenReturn(Future.successful(None))
+    when(lastUpdatedRepository.fetchLastUpdated(any(), any(), any()))
+      .thenReturn(Future.successful(None))
 
     when(
       lastUpdatedRepository.setLastUpdated(
@@ -221,9 +222,18 @@ class ImportStandardCodeListsJobSpec
       .thenReturn(Future.unit)
 
     // Codelist manipulation
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(BC08)))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(BC08),
+        equalTo(None),
+        equalTo(None)
+      )
+    )
       .thenReturn(Future.successful(Set.empty[String]))
-      .thenReturn(Future.successful(Set("BL", "BM")))
+      .thenReturn(
+        Future.successful(Set(CodeListKey("BL", None, None), CodeListKey("BM", None, None)))
+      )
 
     when(codeListsRepository.countEntries(any(), any(), any(), any()))
       .thenReturn(Future.successful(0L))
@@ -333,10 +343,10 @@ class ImportStandardCodeListsJobSpec
 
     when(appConfig.defaultLastUpdated).thenReturn(LocalDate.of(2025, 3, 12))
 
-    when(lastUpdatedRepository.fetchLastUpdated(BC08))
+    when(lastUpdatedRepository.fetchLastUpdated(BC08, None, None))
       .thenReturn(Future.successful(Some(LastUpdated(BC08, 1, None, None, storedInstant))))
 
-    when(lastUpdatedRepository.fetchLastUpdated(BC66))
+    when(lastUpdatedRepository.fetchLastUpdated(BC66, None, None))
       .thenReturn(Future.successful(Some(LastUpdated(BC66, 1, None, None, storedInstant))))
 
     when(
@@ -352,9 +362,18 @@ class ImportStandardCodeListsJobSpec
       .thenReturn(Future.unit)
 
     // Codelist manipulation
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(BC08)))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(BC08),
+        equalTo(None),
+        equalTo(None)
+      )
+    )
       .thenReturn(Future.successful(Set.empty[String]))
-      .thenReturn(Future.successful(Set("BL", "BM")))
+      .thenReturn(
+        Future.successful(Set(CodeListKey("BL", None, None), CodeListKey("BM", None, None)))
+      )
 
     when(codeListsRepository.countEntries(any(), any(), any(), any()))
       .thenReturn(Future.successful(0L))
@@ -427,7 +446,8 @@ class ImportStandardCodeListsJobSpec
     // Last updated date
     when(appConfig.defaultLastUpdated).thenReturn(lastUpdated)
 
-    when(lastUpdatedRepository.fetchLastUpdated(any())).thenReturn(Future.successful(None))
+    when(lastUpdatedRepository.fetchLastUpdated(any(), any(), any()))
+      .thenReturn(Future.successful(None))
 
     when(
       lastUpdatedRepository.setLastUpdated(
@@ -442,9 +462,18 @@ class ImportStandardCodeListsJobSpec
       .thenReturn(Future.unit)
 
     // Codelist manipulation
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(BC08)))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(BC08),
+        equalTo(None),
+        equalTo(None)
+      )
+    )
       .thenReturn(Future.successful(Set.empty[String]))
-      .thenReturn(Future.successful(Set("BL", "BM")))
+      .thenReturn(
+        Future.successful(Set(CodeListKey("BL", None, None), CodeListKey("BM", None, None)))
+      )
 
     when(codeListsRepository.countEntries(any(), any(), any(), any()))
       .thenReturn(Future.successful(0L))
@@ -552,7 +581,14 @@ class ImportStandardCodeListsJobSpec
   }
 
   "ImportCodeListsJob.processSnapshot" should "produce a list of instructions for a snapshot that contains only new entries" in {
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(BC08)))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(BC08),
+        equalTo(None),
+        equalTo(None)
+      )
+    )
       .thenReturn(Future.successful(Set.empty[String]))
 
     val codeListConfig = CodeListConfig(BC08, SEED, "CountryCode")
@@ -601,8 +637,17 @@ class ImportStandardCodeListsJobSpec
   }
 
   it should "produce a list of instructions for a snapshot which contains invalidations and missing entries" in {
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(BC08)))
-      .thenReturn(Future.successful(Set("BL", "BM")))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(BC08),
+        equalTo(None),
+        equalTo(None)
+      )
+    )
+      .thenReturn(
+        Future.successful(Set(CodeListKey("BL", None, None), CodeListKey("BM", None, None)))
+      )
 
     val codeListConfig = CodeListConfig(BC08, SEED, "CountryCode")
 
@@ -645,7 +690,7 @@ class ImportStandardCodeListsJobSpec
           None
         )
       ),
-      RecordMissingEntry(BC08, "BM", fixedInstant),
+      RecordMissingEntry(BC08, "BM", None, None, fixedInstant),
       UpsertEntry(
         CodeListEntry(
           BC08,
@@ -680,8 +725,15 @@ class ImportStandardCodeListsJobSpec
   }
 
   it should "pick the latest entry by modification date and action identification when there are duplicate entries for a given key and activation date" in {
-    when(codeListsRepository.fetchEntryKeys(equalTo(clientSession), equalTo(BC36)))
-      .thenReturn(Future.successful(Set("E470")))
+    when(
+      codeListsRepository.fetchEntryKeys(
+        equalTo(clientSession),
+        equalTo(BC36),
+        equalTo(None),
+        equalTo(None)
+      )
+    )
+      .thenReturn(Future.successful(Set(CodeListKey("E470", None, None))))
 
     val codeListConfig = CodeListConfig(BC36, SEED, "ExciseProductCode")
 


### PR DESCRIPTION
Manage CodeLists Snapshots and Entries by making Phase/Domain a part of their keys so that 'the same' entry key doesn't overwrite other versions
This has been identified because of "test" versions of what are actually P6 lists that we're preloaded into the system before Phase and Domain was added to the cache. We now need to handle the fact that there are multiple "versions" of lists with the same key that need to exist in parallel as currently the "P5" (i.e: no phase and domain) version is preventing the P6 data from loading is as it is being identified as "the list already exists".